### PR TITLE
[codex] Add initial wifi-id application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+
+# Virtual environments
+.venv/
+venv/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Local/generated run outputs
+runs/
+examples/captures/
+
+# Local wireless captures
+*.pcap
+*.pcapng
+*.cap
+
+# OS/editor
+.DS_Store
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# wifi-id
+
+`wifi-id` is a passive Python 3.11+ application for per-frame device identification in encrypted 802.11 monitor-mode captures. It follows the method described in *Identification in Encrypted Wireless Networks Using Supervised Learning* by Christopher Swartz and Anupam Joshi: classify each observed 802.11 frame using only unencrypted Radiotap metadata and 802.11 MAC-header fields.
+
+The tool does not decrypt traffic, inspect payloads, inject frames, transmit probes, or exploit networks. Use it only where you are authorized to capture and analyze wireless traffic.
+
+## Install
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e ".[dev]"
+```
+
+## Quick Start
+
+```bash
+wifi-id ingest --config configs/example.yaml
+wifi-id features --config configs/example.yaml
+wifi-id label --config configs/example.yaml
+wifi-id eval-prequential --config configs/example.yaml
+wifi-id report --config configs/example.yaml
+```
+
+All commands accept a YAML config and targeted path/model overrides. Internal datasets are Parquet by default; CSV export is supported for interoperability.
+
+## Faithful Feature Policy
+
+The default pipeline preserves MAC addresses for labeling, filtering, reporting, and diagnostics, but drops `source_mac` and `destination_mac` from model features. This prevents trivial identity leakage. To run an explicit ablation or sanity check, set:
+
+```yaml
+features:
+  leakage_debug: true
+```
+
+Reports generated from leakage/debug runs are marked accordingly.
+
+## Model Mapping
+
+The paper used MOA/Weka streaming classifiers. `wifi-id` uses native Python `river` models behind a stable application interface:
+
+| Application ID | Native Python mapping |
+| --- | --- |
+| `leveraging_bag` | `river.ensemble.LeveragingBaggingClassifier` with a Hoeffding-tree base learner |
+| `oza_boost` | `river.ensemble.AdaBoostClassifier`, the closest native online boosting equivalent |
+| `oza_boost_adwin` | `river.ensemble.ADWINBoostingClassifier`, falling back to `ADWINBaggingClassifier` if the installed River version lacks ADWIN boosting |
+| `adaptive_hoeffding_tree` | `river.tree.HoeffdingAdaptiveTreeClassifier` |
+
+The abstraction leaves room for a later MOA adapter if strict parity is required.
+
+## CLI Commands
+
+```bash
+wifi-id ingest
+wifi-id features
+wifi-id label
+wifi-id sample
+wifi-id split
+wifi-id feature-rank
+wifi-id train-online
+wifi-id eval-prequential
+wifi-id eval-holdout
+wifi-id classify-file
+wifi-id classify-live
+wifi-id report
+```
+
+`classify-live` is passive-only. It reads from a preconfigured monitor-mode interface and does not perform channel hopping or interface setup.
+
+## Output Artifacts
+
+Typical runs create:
+
+- normalized packet records
+- feature datasets
+- labeled datasets
+- model checkpoints
+- per-frame predictions
+- rolling target-presence summaries
+- JSON/CSV metrics
+- confusion matrices and plots
+- Markdown experiment reports

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -1,0 +1,67 @@
+input:
+  paths:
+    - examples/captures
+  live_interface: null
+target_registry_path: configs/targets.yaml
+output_dir: runs/example
+random_seed: 42
+
+features:
+  data_size_mode: dot11_frame_len
+  leakage_debug: false
+  impute_numeric: -1.0
+  impute_categorical: missing
+
+labeling:
+  mode: binary_one_vs_rest
+  target_id: iphone_5_user1
+  positive_label: target
+  negative_label: other
+
+filters:
+  known_targets_only: false
+  include_ap_originated: true
+  include_management: true
+  include_control: true
+  include_data: true
+  channel_frequency: null
+  start_time: null
+  end_time: null
+  rssi_min: null
+  rssi_max: null
+  min_frame_size: null
+  ap_macs: []
+
+model:
+  model_id: leveraging_bag
+  checkpoint_path: runs/example/model.pkl
+  params:
+    n_models: 5
+
+data:
+  normalized_path: runs/example/records.parquet
+  features_path: runs/example/features.parquet
+  labeled_path: runs/example/labeled.parquet
+  train_path: runs/example/train.parquet
+  test_path: runs/example/test.parquet
+  predictions_path: runs/example/predictions.parquet
+  rolling_path: runs/example/rolling.parquet
+  metrics_path: runs/example/metrics.json
+
+sampling:
+  percentage: 100
+  balance_strategy: none
+  class_weight_column: sample_weight
+
+split:
+  train_fraction: 0.9
+  chronological: true
+
+windowing:
+  frame_count: 100
+  time_seconds: 30
+  min_frames: 5
+  present_ratio_threshold: 0.5
+  mean_probability_threshold: 0.5
+  max_probability_threshold: 0.8
+

--- a/configs/targets.yaml
+++ b/configs/targets.yaml
@@ -1,0 +1,12 @@
+targets:
+  - target_id: iphone_5_user1
+    label: phone
+    mac_addresses:
+      - aa:bb:cc:dd:ee:ff
+    enabled: true
+  - target_id: lg_tv
+    label: tv
+    mac_addresses:
+      - 11:22:33:44:55:66
+    enabled: true
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# Examples
+
+Place monitor-mode PCAP or PCAPNG files under `examples/captures/`, then run:
+
+```bash
+wifi-id ingest --config configs/example.yaml
+```
+
+The repository intentionally does not include real wireless captures.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "wifi-id"
+version = "0.1.0"
+description = "Passive per-frame device identification for encrypted 802.11 captures."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "wifi-id contributors" }]
+dependencies = [
+  "matplotlib>=3.8",
+  "numpy>=1.26",
+  "polars>=0.20",
+  "pyarrow>=15",
+  "pydantic>=2.6",
+  "pydantic-settings>=2.2",
+  "PyYAML>=6.0",
+  "river>=0.21",
+  "scapy>=2.5",
+  "scikit-learn>=1.4",
+  "typer>=0.12",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "ruff>=0.4",
+]
+
+[project.scripts]
+wifi-id = "wifi_id.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/wifi_id"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+

--- a/src/wifi_id/__init__.py
+++ b/src/wifi_id/__init__.py
@@ -1,0 +1,8 @@
+"""Passive 802.11 device-identification toolkit."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"
+

--- a/src/wifi_id/api/__init__.py
+++ b/src/wifi_id/api/__init__.py
@@ -1,0 +1,2 @@
+"""Programmatic API surface."""
+

--- a/src/wifi_id/api/app.py
+++ b/src/wifi_id/api/app.py
@@ -1,0 +1,24 @@
+"""Small programmatic API for embedding the pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wifi_id.config import AppConfig
+from wifi_id.data.readers import iter_rows
+from wifi_id.data.writers import write_rows
+from wifi_id.inference.classify import classify_rows
+from wifi_id.models.base import load_checkpoint
+
+
+def classify_dataset(config: AppConfig, input_path: str | Path, output_path: str | Path) -> int:
+    model = load_checkpoint(config.model.checkpoint_path)
+    predictions = classify_rows(
+        iter_rows(input_path),
+        model,
+        config.features,
+        label_mode=config.labeling.mode,
+        positive_label=config.labeling.positive_label,
+    )
+    return write_rows(output_path, predictions)
+

--- a/src/wifi_id/capture/__init__.py
+++ b/src/wifi_id/capture/__init__.py
@@ -1,0 +1,2 @@
+"""Capture sources."""
+

--- a/src/wifi_id/capture/live.py
+++ b/src/wifi_id/capture/live.py
@@ -1,0 +1,37 @@
+"""Passive live monitor-mode packet source."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from wifi_id.parsing.dot11 import parse_packet_to_record
+from wifi_id.parsing.radiotap import extract_radiotap_fields
+from wifi_id.parsing.records import PacketRecord
+
+
+def iter_live_records(
+    interface: str,
+    *,
+    timeout_seconds: float | None = None,
+    max_packets: int | None = None,
+) -> Iterator[PacketRecord]:
+    """Yield live packets from an already-configured monitor-mode interface.
+
+    This is intentionally passive. It does not configure the interface, hop
+    channels, inject frames, or transmit probe traffic.
+    """
+    try:
+        from scapy.sendrecv import sniff  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("Scapy is required for live classification") from exc
+
+    index = 0
+    while max_packets is None or index < max_packets:
+        packets = sniff(iface=interface, count=1, timeout=timeout_seconds, store=True)
+        if not packets:
+            break
+        packet = packets[0]
+        radiotap = extract_radiotap_fields(packet)
+        yield parse_packet_to_record(packet, f"live:{interface}", index, radiotap)
+        index += 1
+

--- a/src/wifi_id/capture/sources.py
+++ b/src/wifi_id/capture/sources.py
@@ -1,0 +1,66 @@
+"""Offline PCAP/PCAPNG packet sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+from wifi_id.parsing.dot11 import parse_packet_to_record
+from wifi_id.parsing.radiotap import extract_radiotap_fields
+from wifi_id.parsing.records import PacketRecord
+
+
+PCAP_SUFFIXES = {".pcap", ".pcapng", ".cap"}
+
+
+@dataclass(frozen=True)
+class PacketEnvelope:
+    source_file: str
+    packet_index: int
+    packet: Any
+
+
+def expand_input_paths(paths: Iterable[str | Path]) -> list[Path]:
+    expanded: list[Path] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_dir():
+            expanded.extend(
+                sorted(child for child in path.rglob("*") if child.suffix.lower() in PCAP_SUFFIXES)
+            )
+        elif path.exists():
+            expanded.append(path)
+    return expanded
+
+
+def _reader_for_path(path: Path) -> Any:
+    try:
+        from scapy.utils import PcapNgReader, PcapReader  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("Scapy is required for PCAP ingestion") from exc
+
+    if path.suffix.lower() == ".pcapng":
+        return PcapNgReader(str(path))
+    return PcapReader(str(path))
+
+
+def iter_packets(paths: Iterable[str | Path]) -> Iterator[PacketEnvelope]:
+    for path in expand_input_paths(paths):
+        reader = _reader_for_path(path)
+        try:
+            for index, packet in enumerate(reader):
+                yield PacketEnvelope(str(path), index, packet)
+        finally:
+            reader.close()
+
+
+def iter_packet_records(paths: Iterable[str | Path]) -> Iterator[PacketRecord]:
+    for envelope in iter_packets(paths):
+        radiotap = extract_radiotap_fields(envelope.packet)
+        yield parse_packet_to_record(
+            envelope.packet,
+            envelope.source_file,
+            envelope.packet_index,
+            radiotap,
+        )

--- a/src/wifi_id/cli.py
+++ b/src/wifi_id/cli.py
@@ -1,0 +1,343 @@
+"""Typer CLI for wifi-id."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+from wifi_id.capture.live import iter_live_records
+from wifi_id.capture.sources import iter_packet_records
+from wifi_id.config import AppConfig, load_config, write_run_config
+from wifi_id.data.readers import iter_rows
+from wifi_id.data.sampling import balance_file, random_sample_file
+from wifi_id.data.splits import split_file
+from wifi_id.data.writers import write_json, write_rows
+from wifi_id.evaluation.holdout import evaluate_holdout_rows, train_online_rows
+from wifi_id.evaluation.plots import plot_binary_curves, plot_confusion_matrix, write_confusion_matrix_csv
+from wifi_id.evaluation.prequential import evaluate_prequential_rows
+from wifi_id.evaluation.reports import write_markdown_report
+from wifi_id.features.extract import iter_feature_rows, model_feature_names
+from wifi_id.features.selection import rank_feature_file
+from wifi_id.inference.aggregate import rolling_aggregates
+from wifi_id.inference.classify import classify_rows
+from wifi_id.labeling.filters import passes_filters
+from wifi_id.labeling.labelers import iter_labeled_rows
+from wifi_id.labeling.targets import TargetRegistry
+from wifi_id.models.base import load_checkpoint
+from wifi_id.models.registry import create_model
+
+app = typer.Typer(no_args_is_help=True, help="Passive 802.11 device identification.")
+
+ConfigOption = Annotated[Path, typer.Option("--config", "-c", exists=True, help="YAML config path.")]
+
+
+@app.command()
+def ingest(
+    config: ConfigOption,
+    input_path: Annotated[Optional[list[Path]], typer.Option("--input", "-i")] = None,
+    output: Annotated[Optional[Path], typer.Option("--output", "-o")] = None,
+) -> None:
+    cfg = load_config(config)
+    paths = input_path or cfg.input.paths
+    output_path = output or cfg.data.normalized_path
+    _write_run_config(cfg)
+    count = write_rows(output_path, (record.to_dict() for record in iter_packet_records(paths)))
+    typer.echo(f"Wrote {count} normalized packet records to {output_path}")
+
+
+@app.command("features")
+def features_command(
+    config: ConfigOption,
+    input_path: Annotated[Optional[Path], typer.Option("--input", "-i")] = None,
+    output: Annotated[Optional[Path], typer.Option("--output", "-o")] = None,
+) -> None:
+    cfg = load_config(config)
+    source = input_path or cfg.data.normalized_path
+    output_path = output or cfg.data.features_path
+    rows = (row for row in iter_rows(source) if row.get("parse_ok", True))
+    count = write_rows(output_path, iter_feature_rows(rows, cfg.features))
+    typer.echo(f"Wrote {count} feature rows to {output_path}")
+
+
+@app.command()
+def label(
+    config: ConfigOption,
+    input_path: Annotated[Optional[Path], typer.Option("--input", "-i")] = None,
+    output: Annotated[Optional[Path], typer.Option("--output", "-o")] = None,
+) -> None:
+    cfg = load_config(config)
+    registry = _target_registry(cfg)
+    source = input_path or cfg.data.features_path
+    output_path = output or cfg.data.labeled_path
+
+    def filtered_rows():
+        for row in iter_rows(source):
+            if passes_filters(row, cfg.filters, registry=registry):
+                yield row
+
+    count = write_rows(output_path, iter_labeled_rows(filtered_rows(), registry, cfg.labeling))
+    typer.echo(f"Wrote {count} labeled rows to {output_path}")
+
+
+@app.command()
+def sample(
+    config: ConfigOption,
+    input_path: Annotated[Optional[Path], typer.Option("--input", "-i")] = None,
+    output: Annotated[Optional[Path], typer.Option("--output", "-o")] = None,
+    percentage: Annotated[Optional[float], typer.Option("--percentage")] = None,
+    balance_strategy: Annotated[Optional[str], typer.Option("--balance-strategy")] = None,
+) -> None:
+    cfg = load_config(config)
+    source = input_path or cfg.data.labeled_path
+    output_path = output or cfg.data.labeled_path.with_name("sampled" + cfg.data.labeled_path.suffix)
+    strategy = balance_strategy or cfg.sampling.balance_strategy
+    if strategy and strategy.lower() not in {"none", "off"}:
+        count = balance_file(
+            source,
+            output_path,
+            strategy=strategy,
+            seed=cfg.random_seed,
+            class_weight_column=cfg.sampling.class_weight_column,
+        )
+    else:
+        count = random_sample_file(
+            source,
+            output_path,
+            percentage=percentage if percentage is not None else cfg.sampling.percentage,
+            seed=cfg.random_seed,
+        )
+    typer.echo(f"Wrote {count} sampled rows to {output_path}")
+
+
+@app.command()
+def split(
+    config: ConfigOption,
+    input_path: Annotated[Optional[Path], typer.Option("--input", "-i")] = None,
+    train_output: Annotated[Optional[Path], typer.Option("--train-output")] = None,
+    test_output: Annotated[Optional[Path], typer.Option("--test-output")] = None,
+) -> None:
+    cfg = load_config(config)
+    train_count, test_count = split_file(
+        input_path or cfg.data.labeled_path,
+        train_output or cfg.data.train_path,
+        test_output or cfg.data.test_path,
+        train_fraction=cfg.split.train_fraction,
+        chronological=cfg.split.chronological,
+        seed=cfg.random_seed,
+    )
+    typer.echo(f"Wrote {train_count} train rows and {test_count} test rows")
+
+
+@app.command("feature-rank")
+def feature_rank(
+    config: ConfigOption,
+    input_path: Annotated[Optional[Path], typer.Option("--input", "-i")] = None,
+    output_json: Annotated[Optional[Path], typer.Option("--output-json")] = None,
+    output_markdown: Annotated[Optional[Path], typer.Option("--output-markdown")] = None,
+    sample_size: Annotated[Optional[int], typer.Option("--sample-size")] = None,
+) -> None:
+    cfg = load_config(config)
+    out_json = output_json or cfg.output_dir / "feature_ranking.json"
+    out_md = output_markdown or cfg.output_dir / "feature_ranking.md"
+    ranked = rank_feature_file(
+        input_path or cfg.data.labeled_path,
+        features=model_feature_names(cfg.features),
+        sample_size=sample_size,
+        seed=cfg.random_seed,
+        output_json=out_json,
+        output_markdown=out_md,
+    )
+    typer.echo(f"Ranked {len(ranked)} features")
+
+
+@app.command("train-online")
+def train_online(
+    config: ConfigOption,
+    input_path: Annotated[Optional[Path], typer.Option("--input", "-i")] = None,
+    checkpoint: Annotated[Optional[Path], typer.Option("--checkpoint")] = None,
+    model_id: Annotated[Optional[str], typer.Option("--model-id")] = None,
+) -> None:
+    cfg = load_config(config)
+    model = create_model(
+        model_id or cfg.model.model_id,
+        feature_names=model_feature_names(cfg.features),
+        seed=cfg.random_seed,
+        params=cfg.model.params,
+    )
+    count = train_online_rows(
+        iter_rows(input_path or cfg.data.labeled_path),
+        model,
+        cfg.features,
+        weight_column=cfg.sampling.class_weight_column,
+    )
+    model.save(checkpoint or cfg.model.checkpoint_path)
+    typer.echo(f"Trained {model.model_id} on {count} rows")
+
+
+@app.command("eval-prequential")
+def eval_prequential(
+    config: ConfigOption,
+    input_path: Annotated[Optional[Path], typer.Option("--input", "-i")] = None,
+    predictions_output: Annotated[Optional[Path], typer.Option("--predictions-output")] = None,
+    metrics_output: Annotated[Optional[Path], typer.Option("--metrics-output")] = None,
+    model_id: Annotated[Optional[str], typer.Option("--model-id")] = None,
+) -> None:
+    cfg = load_config(config)
+    model = create_model(
+        model_id or cfg.model.model_id,
+        feature_names=model_feature_names(cfg.features),
+        seed=cfg.random_seed,
+        params=cfg.model.params,
+    )
+    metrics, predictions = evaluate_prequential_rows(
+        iter_rows(input_path or cfg.data.labeled_path),
+        model,
+        cfg.features,
+        positive_label=cfg.labeling.positive_label,
+        weight_column=cfg.sampling.class_weight_column,
+    )
+    _write_eval_outputs(cfg, metrics, predictions, metrics_output, predictions_output)
+    typer.echo(f"Evaluated {metrics['n_examples']} rows prequentially")
+
+
+@app.command("eval-holdout")
+def eval_holdout(
+    config: ConfigOption,
+    train_input: Annotated[Optional[Path], typer.Option("--train-input")] = None,
+    test_input: Annotated[Optional[Path], typer.Option("--test-input")] = None,
+    predictions_output: Annotated[Optional[Path], typer.Option("--predictions-output")] = None,
+    metrics_output: Annotated[Optional[Path], typer.Option("--metrics-output")] = None,
+    model_id: Annotated[Optional[str], typer.Option("--model-id")] = None,
+) -> None:
+    cfg = load_config(config)
+    model = create_model(
+        model_id or cfg.model.model_id,
+        feature_names=model_feature_names(cfg.features),
+        seed=cfg.random_seed,
+        params=cfg.model.params,
+    )
+    metrics, predictions = evaluate_holdout_rows(
+        iter_rows(train_input or cfg.data.train_path),
+        iter_rows(test_input or cfg.data.test_path),
+        model,
+        cfg.features,
+        positive_label=cfg.labeling.positive_label,
+        weight_column=cfg.sampling.class_weight_column,
+    )
+    _write_eval_outputs(cfg, metrics, predictions, metrics_output, predictions_output)
+    typer.echo(f"Evaluated {metrics['n_examples']} holdout rows")
+
+
+@app.command("classify-file")
+def classify_file(
+    config: ConfigOption,
+    input_path: Annotated[Optional[Path], typer.Option("--input", "-i")] = None,
+    checkpoint: Annotated[Optional[Path], typer.Option("--checkpoint")] = None,
+    predictions_output: Annotated[Optional[Path], typer.Option("--predictions-output")] = None,
+    rolling_output: Annotated[Optional[Path], typer.Option("--rolling-output")] = None,
+    target_class: Annotated[Optional[str], typer.Option("--target-class")] = None,
+) -> None:
+    cfg = load_config(config)
+    model = load_checkpoint(checkpoint or cfg.model.checkpoint_path)
+    predictions = classify_rows(
+        iter_rows(input_path or cfg.data.features_path),
+        model,
+        cfg.features,
+        label_mode=cfg.labeling.mode,
+        positive_label=cfg.labeling.positive_label,
+    )
+    pred_path = predictions_output or cfg.data.predictions_path
+    roll_path = rolling_output or cfg.data.rolling_path
+    write_rows(pred_path, predictions)
+    target = target_class or cfg.labeling.target_id or cfg.labeling.positive_label
+    rolling = rolling_aggregates(predictions, target_class=target, config=cfg.windowing)
+    write_rows(roll_path, rolling)
+    typer.echo(f"Wrote {len(predictions)} predictions and {len(rolling)} rolling rows")
+
+
+@app.command("classify-live")
+def classify_live(
+    config: ConfigOption,
+    interface: Annotated[Optional[str], typer.Option("--interface")] = None,
+    checkpoint: Annotated[Optional[Path], typer.Option("--checkpoint")] = None,
+    output: Annotated[Optional[Path], typer.Option("--output", "-o")] = None,
+    max_packets: Annotated[Optional[int], typer.Option("--max-packets")] = None,
+    timeout_seconds: Annotated[Optional[float], typer.Option("--timeout-seconds")] = None,
+) -> None:
+    cfg = load_config(config)
+    iface = interface or cfg.input.live_interface
+    if not iface:
+        raise typer.BadParameter("A monitor-mode interface is required")
+    model = load_checkpoint(checkpoint or cfg.model.checkpoint_path)
+    feature_rows = iter_feature_rows(
+        iter_live_records(iface, timeout_seconds=timeout_seconds, max_packets=max_packets),
+        cfg.features,
+    )
+    predictions = classify_rows(feature_rows, model, cfg.features, label_mode=cfg.labeling.mode)
+    count = write_rows(output or cfg.data.predictions_path, predictions)
+    typer.echo(f"Wrote {count} live predictions")
+
+
+@app.command()
+def report(
+    config: ConfigOption,
+    metrics_input: Annotated[Optional[Path], typer.Option("--metrics-input")] = None,
+    output: Annotated[Optional[Path], typer.Option("--output", "-o")] = None,
+) -> None:
+    import json
+
+    cfg = load_config(config)
+    metrics_path = metrics_input or cfg.data.metrics_path
+    with Path(metrics_path).open("r", encoding="utf-8") as handle:
+        metrics = json.load(handle)
+    report_path = output or cfg.output_dir / "report.md"
+    write_markdown_report(report_path, config=cfg, metrics=metrics)
+    typer.echo(f"Wrote report to {report_path}")
+
+
+def _target_registry(cfg: AppConfig) -> TargetRegistry:
+    if cfg.target_registry_path is None:
+        raise typer.BadParameter("target_registry_path is required")
+    return TargetRegistry.from_file(cfg.target_registry_path)
+
+
+def _write_run_config(cfg: AppConfig) -> None:
+    write_run_config(cfg, cfg.output_dir)
+
+
+def _write_eval_outputs(
+    cfg: AppConfig,
+    metrics: dict,
+    predictions: list[dict],
+    metrics_output: Path | None,
+    predictions_output: Path | None,
+) -> None:
+    metrics_path = metrics_output or cfg.data.metrics_path
+    predictions_path = predictions_output or cfg.data.predictions_path
+    write_json(metrics_path, metrics)
+    write_rows(predictions_path, predictions)
+    write_confusion_matrix_csv(cfg.output_dir / "confusion_matrix.csv", metrics)
+    try:
+        plot_confusion_matrix(cfg.output_dir / "confusion_matrix.png", metrics)
+    except RuntimeError:
+        pass
+    try:
+        plot_binary_curves(
+            cfg.output_dir / "roc_curve.png",
+            cfg.output_dir / "pr_curve.png",
+            predictions,
+            positive_label=cfg.labeling.positive_label,
+        )
+    except RuntimeError:
+        pass
+    write_markdown_report(cfg.output_dir / "report.md", config=cfg, metrics=metrics)
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/wifi_id/config.py
+++ b/src/wifi_id/config.py
@@ -1,0 +1,129 @@
+"""YAML-driven application configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class InputConfig(BaseModel):
+    paths: List[Path] = Field(default_factory=list)
+    live_interface: Optional[str] = None
+
+
+class FeatureConfig(BaseModel):
+    data_size_mode: str = "dot11_frame_len"
+    leakage_debug: bool = False
+    mac_encoding: str = "hashed"
+    impute_numeric: float = -1.0
+    impute_categorical: str = "missing"
+    include_missing_indicators: bool = False
+
+
+class LabelConfig(BaseModel):
+    mode: str = "binary_one_vs_rest"
+    target_id: Optional[str] = None
+    positive_label: str = "target"
+    negative_label: str = "other"
+
+
+class FilterConfig(BaseModel):
+    known_targets_only: bool = False
+    include_ap_originated: bool = True
+    include_management: bool = True
+    include_control: bool = True
+    include_data: bool = True
+    channel_frequency: Optional[int] = None
+    start_time: Optional[Union[float, str]] = None
+    end_time: Optional[Union[float, str]] = None
+    rssi_min: Optional[float] = None
+    rssi_max: Optional[float] = None
+    min_frame_size: Optional[int] = None
+    ap_macs: List[str] = Field(default_factory=list)
+
+
+class ModelConfig(BaseModel):
+    model_id: str = "leveraging_bag"
+    checkpoint_path: Path = Path("runs/model.pkl")
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class DataConfig(BaseModel):
+    normalized_path: Path = Path("runs/records.parquet")
+    features_path: Path = Path("runs/features.parquet")
+    labeled_path: Path = Path("runs/labeled.parquet")
+    train_path: Path = Path("runs/train.parquet")
+    test_path: Path = Path("runs/test.parquet")
+    predictions_path: Path = Path("runs/predictions.parquet")
+    rolling_path: Path = Path("runs/rolling.parquet")
+    metrics_path: Path = Path("runs/metrics.json")
+
+
+class SamplingConfig(BaseModel):
+    percentage: float = 100.0
+    balance_strategy: str = "none"
+    class_weight_column: str = "sample_weight"
+
+
+class SplitConfig(BaseModel):
+    train_fraction: float = 0.9
+    chronological: bool = True
+
+
+class WindowConfig(BaseModel):
+    frame_count: int = 100
+    time_seconds: int = 30
+    min_frames: int = 5
+    present_ratio_threshold: float = 0.5
+    mean_probability_threshold: float = 0.5
+    max_probability_threshold: float = 0.8
+
+
+class AppConfig(BaseModel):
+    input: InputConfig = Field(default_factory=InputConfig)
+    target_registry_path: Optional[Path] = None
+    output_dir: Path = Path("runs/default")
+    random_seed: int = 42
+    features: FeatureConfig = Field(default_factory=FeatureConfig)
+    labeling: LabelConfig = Field(default_factory=LabelConfig)
+    filters: FilterConfig = Field(default_factory=FilterConfig)
+    model: ModelConfig = Field(default_factory=ModelConfig)
+    data: DataConfig = Field(default_factory=DataConfig)
+    sampling: SamplingConfig = Field(default_factory=SamplingConfig)
+    split: SplitConfig = Field(default_factory=SplitConfig)
+    windowing: WindowConfig = Field(default_factory=WindowConfig)
+
+
+def _validate_config(data: Dict[str, Any]) -> AppConfig:
+    if hasattr(AppConfig, "model_validate"):
+        return AppConfig.model_validate(data)  # type: ignore[attr-defined]
+    return AppConfig.parse_obj(data)
+
+
+def config_to_dict(config: AppConfig) -> Dict[str, Any]:
+    if hasattr(config, "model_dump"):
+        return config.model_dump(mode="json")  # type: ignore[attr-defined]
+    return config.dict()
+
+
+def load_config(path: Union[str, Path]) -> AppConfig:
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as handle:
+        if config_path.suffix.lower() == ".json":
+            data = json.load(handle)
+        else:
+            data = yaml.safe_load(handle) or {}
+    return _validate_config(data)
+
+
+def write_run_config(config: AppConfig, output_dir: Union[str, Path]) -> Path:
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    run_config = output_path / "run_config.json"
+    with run_config.open("w", encoding="utf-8") as handle:
+        json.dump(config_to_dict(config), handle, indent=2, sort_keys=True, default=str)
+    return run_config

--- a/src/wifi_id/data/__init__.py
+++ b/src/wifi_id/data/__init__.py
@@ -1,0 +1,2 @@
+"""Dataset readers, writers, sampling, and splits."""
+

--- a/src/wifi_id/data/readers.py
+++ b/src/wifi_id/data/readers.py
@@ -1,0 +1,71 @@
+"""Chunk-friendly dataset readers."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+
+def iter_rows(path: str | Path, *, batch_size: int = 65_536) -> Iterator[dict[str, Any]]:
+    dataset_path = Path(path)
+    suffix = dataset_path.suffix.lower()
+    if suffix == ".parquet":
+        yield from _iter_parquet_rows(dataset_path, batch_size=batch_size)
+    elif suffix == ".jsonl":
+        with dataset_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip():
+                    yield json.loads(line)
+    else:
+        yield from _iter_csv_rows(dataset_path)
+
+
+def read_all_rows(path: str | Path) -> list[dict[str, Any]]:
+    return list(iter_rows(path))
+
+
+def read_json(path: str | Path) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _iter_csv_rows(path: Path) -> Iterator[dict[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            yield {key: _coerce_csv_value(value) for key, value in row.items()}
+
+
+def _coerce_csv_value(value: str | None) -> Any:
+    if value in {None, ""}:
+        return None
+    text = str(value)
+    lowered = text.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    try:
+        if "." not in text:
+            return int(text)
+    except ValueError:
+        pass
+    try:
+        return float(text)
+    except ValueError:
+        return text
+
+
+def _iter_parquet_rows(path: Path, *, batch_size: int) -> Iterator[dict[str, Any]]:
+    try:
+        import pyarrow.parquet as pq  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("pyarrow is required to read Parquet datasets") from exc
+
+    parquet_file = pq.ParquetFile(path)
+    for batch in parquet_file.iter_batches(batch_size=batch_size):
+        for row in batch.to_pylist():
+            yield row
+

--- a/src/wifi_id/data/sampling.py
+++ b/src/wifi_id/data/sampling.py
@@ -1,0 +1,120 @@
+"""Deterministic sampling and balancing utilities."""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+from wifi_id.data.readers import iter_rows, read_all_rows
+from wifi_id.data.writers import write_rows
+
+
+def random_sample_rows(
+    rows: Iterable[dict[str, Any]],
+    *,
+    percentage: float,
+    seed: int,
+) -> Iterator[dict[str, Any]]:
+    if percentage >= 100:
+        yield from rows
+        return
+    if percentage <= 0:
+        return
+    threshold = percentage / 100.0
+    rng = random.Random(seed)
+    for row in rows:
+        if rng.random() <= threshold:
+            yield row
+
+
+def random_sample_file(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    percentage: float,
+    seed: int,
+) -> int:
+    return write_rows(output_path, random_sample_rows(iter_rows(input_path), percentage=percentage, seed=seed))
+
+
+def balance_rows(
+    rows: Iterable[dict[str, Any]],
+    *,
+    strategy: str,
+    label_column: str = "label",
+    seed: int = 42,
+    class_weight_column: str = "sample_weight",
+) -> Iterator[dict[str, Any]]:
+    strategy = strategy.lower()
+    if strategy in {"none", "off", ""}:
+        yield from rows
+        return
+
+    buckets: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        label = row.get(label_column)
+        if label is not None:
+            buckets[str(label)].append(row)
+
+    if not buckets:
+        return
+
+    rng = random.Random(seed)
+    counts = {label: len(label_rows) for label, label_rows in buckets.items()}
+
+    if strategy == "downsample":
+        target_count = min(counts.values())
+        output: list[dict[str, Any]] = []
+        for label, label_rows in buckets.items():
+            output.extend(rng.sample(label_rows, target_count))
+        rng.shuffle(output)
+        yield from output
+        return
+
+    if strategy == "upsample":
+        target_count = max(counts.values())
+        output = []
+        for label_rows in buckets.values():
+            output.extend(label_rows)
+            for _ in range(target_count - len(label_rows)):
+                output.append(dict(rng.choice(label_rows)))
+        rng.shuffle(output)
+        yield from output
+        return
+
+    if strategy in {"class_weight", "weights"}:
+        total = sum(counts.values())
+        n_classes = len(counts)
+        for label_rows in buckets.values():
+            label = str(label_rows[0][label_column])
+            weight = total / (n_classes * counts[label])
+            for row in label_rows:
+                output_row = dict(row)
+                output_row[class_weight_column] = weight
+                yield output_row
+        return
+
+    raise ValueError(f"Unsupported balance strategy: {strategy}")
+
+
+def balance_file(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    strategy: str,
+    label_column: str = "label",
+    seed: int = 42,
+    class_weight_column: str = "sample_weight",
+) -> int:
+    return write_rows(
+        output_path,
+        balance_rows(
+            read_all_rows(input_path),
+            strategy=strategy,
+            label_column=label_column,
+            seed=seed,
+            class_weight_column=class_weight_column,
+        ),
+    )

--- a/src/wifi_id/data/splits.py
+++ b/src/wifi_id/data/splits.py
@@ -1,0 +1,77 @@
+"""Train/test split utilities."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Any, Iterator
+
+from wifi_id.data.readers import iter_rows, read_all_rows
+from wifi_id.data.writers import write_rows
+
+
+def chronological_split_file(
+    input_path: str | Path,
+    train_path: str | Path,
+    test_path: str | Path,
+    *,
+    train_fraction: float,
+) -> tuple[int, int]:
+    total = sum(1 for _ in iter_rows(input_path))
+    train_count = int(total * train_fraction)
+
+    def train_rows() -> Iterator[dict[str, Any]]:
+        for index, row in enumerate(iter_rows(input_path)):
+            if index < train_count:
+                yield row
+
+    def test_rows() -> Iterator[dict[str, Any]]:
+        for index, row in enumerate(iter_rows(input_path)):
+            if index >= train_count:
+                yield row
+
+    written_train = write_rows(train_path, train_rows())
+    written_test = write_rows(test_path, test_rows())
+    return written_train, written_test
+
+
+def holdout_split_file(
+    input_path: str | Path,
+    train_path: str | Path,
+    test_path: str | Path,
+    *,
+    train_fraction: float,
+    seed: int,
+) -> tuple[int, int]:
+    rows = read_all_rows(input_path)
+    rng = random.Random(seed)
+    rng.shuffle(rows)
+    train_count = int(len(rows) * train_fraction)
+    written_train = write_rows(train_path, rows[:train_count])
+    written_test = write_rows(test_path, rows[train_count:])
+    return written_train, written_test
+
+
+def split_file(
+    input_path: str | Path,
+    train_path: str | Path,
+    test_path: str | Path,
+    *,
+    train_fraction: float,
+    chronological: bool,
+    seed: int,
+) -> tuple[int, int]:
+    if chronological:
+        return chronological_split_file(
+            input_path,
+            train_path,
+            test_path,
+            train_fraction=train_fraction,
+        )
+    return holdout_split_file(
+        input_path,
+        train_path,
+        test_path,
+        train_fraction=train_fraction,
+        seed=seed,
+    )

--- a/src/wifi_id/data/writers.py
+++ b/src/wifi_id/data/writers.py
@@ -1,0 +1,129 @@
+"""Dataset writers."""
+
+from __future__ import annotations
+
+import csv
+import json
+from itertools import islice
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+def write_rows(path: str | Path, rows: Iterable[dict[str, Any]], *, chunk_size: int = 10_000) -> int:
+    dataset_path = Path(path)
+    dataset_path.parent.mkdir(parents=True, exist_ok=True)
+    suffix = dataset_path.suffix.lower()
+    if suffix == ".parquet":
+        return _write_parquet_rows(dataset_path, rows, chunk_size=chunk_size)
+    if suffix == ".jsonl":
+        return _write_jsonl_rows(dataset_path, rows)
+    if suffix == ".arff":
+        return _write_arff_rows(dataset_path, rows)
+    return _write_csv_rows(dataset_path, rows)
+
+
+def write_json(path: str | Path, data: dict[str, Any]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+
+
+def _chunks(iterator: Iterator[dict[str, Any]], size: int) -> Iterator[list[dict[str, Any]]]:
+    while True:
+        chunk = list(islice(iterator, size))
+        if not chunk:
+            break
+        yield chunk
+
+
+def _write_csv_rows(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+    iterator = iter(rows)
+    first = next(iterator, None)
+    if first is None:
+        path.write_text("", encoding="utf-8")
+        return 0
+    fieldnames = list(first.keys())
+    count = 0
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerow(first)
+        count += 1
+        for row in iterator:
+            for key in row.keys():
+                if key not in fieldnames:
+                    fieldnames.append(key)
+                    raise ValueError(
+                        f"CSV schema changed while writing {path}; new field {key!r} appeared"
+                    )
+            writer.writerow(row)
+            count += 1
+    return count
+
+
+def _write_jsonl_rows(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+    count = 0
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+            count += 1
+    return count
+
+
+def _write_arff_rows(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+    buffered = list(rows)
+    if not buffered:
+        path.write_text("@RELATION wifi_id\n\n@DATA\n", encoding="utf-8")
+        return 0
+    fieldnames = list(buffered[0].keys())
+    lines = ["@RELATION wifi_id", ""]
+    for field in fieldnames:
+        values = [row.get(field) for row in buffered if row.get(field) is not None]
+        if values and all(isinstance(value, (int, float, bool)) for value in values):
+            kind = "NUMERIC"
+        else:
+            kind = "STRING"
+        lines.append(f"@ATTRIBUTE {field} {kind}")
+    lines.extend(["", "@DATA"])
+    for row in buffered:
+        values = [_arff_value(row.get(field)) for field in fieldnames]
+        lines.append(",".join(values))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return len(buffered)
+
+
+def _arff_value(value: Any) -> str:
+    if value is None:
+        return "?"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return "'" + str(value).replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _write_parquet_rows(path: Path, rows: Iterable[dict[str, Any]], *, chunk_size: int) -> int:
+    try:
+        import pyarrow as pa  # type: ignore
+        import pyarrow.parquet as pq  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("pyarrow is required to write Parquet datasets") from exc
+
+    iterator = iter(rows)
+    writer = None
+    count = 0
+    try:
+        for chunk in _chunks(iterator, chunk_size):
+            table = pa.Table.from_pylist(chunk)
+            if writer is None:
+                writer = pq.ParquetWriter(path, table.schema)
+            writer.write_table(table)
+            count += len(chunk)
+    finally:
+        if writer is not None:
+            writer.close()
+    if writer is None:
+        empty = pa.Table.from_pylist([])
+        pq.write_table(empty, path)
+    return count

--- a/src/wifi_id/evaluation/__init__.py
+++ b/src/wifi_id/evaluation/__init__.py
@@ -1,0 +1,2 @@
+"""Evaluation metrics, prequential loops, holdout loops, plots, and reports."""
+

--- a/src/wifi_id/evaluation/holdout.py
+++ b/src/wifi_id/evaluation/holdout.py
@@ -1,0 +1,90 @@
+"""Classic train/test holdout evaluation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from wifi_id.config import FeatureConfig
+from wifi_id.evaluation.metrics import classification_metrics
+from wifi_id.features.extract import row_to_model_features
+from wifi_id.models.base import OnlineModel
+from wifi_id.parsing.records import PredictionRow
+
+
+def train_online_rows(
+    rows: Iterable[dict[str, Any]],
+    model: OnlineModel,
+    feature_config: FeatureConfig,
+    *,
+    label_column: str = "label",
+    weight_column: str | None = None,
+) -> int:
+    count = 0
+    for row in rows:
+        label = row.get(label_column)
+        if label is None:
+            continue
+        features = row_to_model_features(row, feature_config)
+        weight = None if weight_column is None else row.get(weight_column)
+        model.learn_one(features, str(label), None if weight is None else float(weight))
+        count += 1
+    return count
+
+
+def evaluate_holdout_rows(
+    train_rows: Iterable[dict[str, Any]],
+    test_rows: Iterable[dict[str, Any]],
+    model: OnlineModel,
+    feature_config: FeatureConfig,
+    *,
+    label_column: str = "label",
+    positive_label: str = "target",
+    weight_column: str | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    train_count = train_online_rows(
+        train_rows,
+        model,
+        feature_config,
+        label_column=label_column,
+        weight_column=weight_column,
+    )
+    y_true: list[str] = []
+    y_pred: list[str] = []
+    y_score: list[float] = []
+    predictions: list[dict[str, Any]] = []
+
+    for row in test_rows:
+        label = row.get(label_column)
+        if label is None:
+            continue
+        features = row_to_model_features(row, feature_config)
+        probabilities = model.predict_proba_one(features)
+        prediction = model.predict_one(features)
+        if prediction is None and probabilities:
+            prediction = max(probabilities, key=probabilities.get)
+        prediction = prediction or "__none__"
+        confidence = probabilities.get(prediction)
+        if confidence is None and probabilities:
+            confidence = max(probabilities.values())
+        y_true.append(str(label))
+        y_pred.append(str(prediction))
+        y_score.append(float(probabilities.get(positive_label, 0.0)))
+        predictions.append(
+            PredictionRow(
+                timestamp=row.get("timestamp"),
+                packet_index=int(row.get("packet_index") or len(predictions)),
+                label_mode=str(row.get("label_mode") or "unknown"),
+                predicted_class=str(prediction),
+                confidence=confidence,
+                ground_truth=str(label),
+                source_mac=row.get("source_mac"),
+                destination_mac=row.get("destination_mac"),
+                features_json=json.dumps(features, sort_keys=True),
+                probabilities_json=json.dumps(probabilities, sort_keys=True),
+            ).to_dict()
+        )
+
+    metrics = classification_metrics(y_true, y_pred, y_score=y_score, positive_label=positive_label)
+    metrics["train_examples"] = train_count
+    return metrics, predictions

--- a/src/wifi_id/evaluation/metrics.py
+++ b/src/wifi_id/evaluation/metrics.py
@@ -1,0 +1,134 @@
+"""Classification metrics with sklearn-backed AUCs when available."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Any
+
+
+def classification_metrics(
+    y_true: list[str],
+    y_pred: list[str],
+    *,
+    y_score: list[float] | None = None,
+    positive_label: str = "target",
+) -> dict[str, Any]:
+    labels = sorted(set(y_true) | set(y_pred))
+    matrix = confusion_matrix(y_true, y_pred, labels)
+    total = len(y_true)
+    correct = sum(1 for truth, pred in zip(y_true, y_pred) if truth == pred)
+    accuracy = correct / total if total else 0.0
+
+    per_class = per_class_metrics(matrix, labels)
+    precision, recall, f1 = _primary_precision_recall_f1(per_class, positive_label)
+    mcc = matthews_corrcoef(matrix, labels)
+
+    metrics: dict[str, Any] = {
+        "n_examples": total,
+        "labels": labels,
+        "accuracy": accuracy,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "mcc": mcc,
+        "per_class": per_class,
+        "confusion_matrix": {
+            "labels": labels,
+            "matrix": matrix,
+        },
+    }
+
+    aucs = binary_auc_metrics(y_true, y_score, positive_label=positive_label)
+    metrics.update(aucs)
+    return metrics
+
+
+def confusion_matrix(y_true: list[str], y_pred: list[str], labels: list[str]) -> list[list[int]]:
+    index = {label: idx for idx, label in enumerate(labels)}
+    matrix = [[0 for _ in labels] for _ in labels]
+    for truth, pred in zip(y_true, y_pred):
+        matrix[index[truth]][index[pred]] += 1
+    return matrix
+
+
+def per_class_metrics(matrix: list[list[int]], labels: list[str]) -> dict[str, dict[str, float]]:
+    result: dict[str, dict[str, float]] = {}
+    supports = [sum(row) for row in matrix]
+    columns = [sum(matrix[row][col] for row in range(len(labels))) for col in range(len(labels))]
+    for idx, label in enumerate(labels):
+        tp = matrix[idx][idx]
+        fp = columns[idx] - tp
+        fn = supports[idx] - tp
+        precision = tp / (tp + fp) if tp + fp else 0.0
+        recall = tp / (tp + fn) if tp + fn else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+        result[label] = {
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "support": float(supports[idx]),
+        }
+    return result
+
+
+def matthews_corrcoef(matrix: list[list[int]], labels: list[str]) -> float | None:
+    if not labels:
+        return None
+    n = sum(sum(row) for row in matrix)
+    if n == 0:
+        return None
+    trace = sum(matrix[i][i] for i in range(len(labels)))
+    row_sums = [sum(row) for row in matrix]
+    col_sums = [sum(matrix[row][col] for row in range(len(labels))) for col in range(len(labels))]
+    cov_ytyp = trace * n - sum(row_sums[i] * col_sums[i] for i in range(len(labels)))
+    cov_ypyp = n * n - sum(value * value for value in col_sums)
+    cov_ytyt = n * n - sum(value * value for value in row_sums)
+    denominator = math.sqrt(cov_ytyt * cov_ypyp)
+    if denominator == 0:
+        return None
+    return cov_ytyp / denominator
+
+
+def binary_auc_metrics(
+    y_true: list[str],
+    y_score: list[float] | None,
+    *,
+    positive_label: str,
+) -> dict[str, float | None]:
+    if not y_score or len(set(y_true)) < 2:
+        return {"roc_auc": None, "pr_auc": None}
+    try:
+        from sklearn.metrics import average_precision_score, roc_auc_score  # type: ignore
+    except Exception:
+        return {"roc_auc": None, "pr_auc": None}
+    truth = [1 if label == positive_label else 0 for label in y_true]
+    try:
+        return {
+            "roc_auc": float(roc_auc_score(truth, y_score)),
+            "pr_auc": float(average_precision_score(truth, y_score)),
+        }
+    except Exception:
+        return {"roc_auc": None, "pr_auc": None}
+
+
+def class_distribution(rows: list[dict[str, Any]], label_column: str = "label") -> dict[str, int]:
+    return dict(Counter(str(row[label_column]) for row in rows if row.get(label_column) is not None))
+
+
+def _primary_precision_recall_f1(
+    per_class: dict[str, dict[str, float]],
+    positive_label: str,
+) -> tuple[float, float, float]:
+    if positive_label in per_class:
+        item = per_class[positive_label]
+        return item["precision"], item["recall"], item["f1"]
+
+    total_support = sum(item["support"] for item in per_class.values())
+    if total_support == 0:
+        return 0.0, 0.0, 0.0
+    precision = sum(item["precision"] * item["support"] for item in per_class.values()) / total_support
+    recall = sum(item["recall"] * item["support"] for item in per_class.values()) / total_support
+    f1 = sum(item["f1"] * item["support"] for item in per_class.values()) / total_support
+    return precision, recall, f1
+

--- a/src/wifi_id/evaluation/plots.py
+++ b/src/wifi_id/evaluation/plots.py
@@ -1,0 +1,102 @@
+"""Plot helpers for generated reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_confusion_matrix_csv(path: str | Path, metrics: dict[str, Any]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    labels = metrics["confusion_matrix"]["labels"]
+    matrix = metrics["confusion_matrix"]["matrix"]
+    lines = ["," + ",".join(labels)]
+    for label, row in zip(labels, matrix):
+        lines.append(",".join([label, *[str(value) for value in row]]))
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def plot_confusion_matrix(path: str | Path, metrics: dict[str, Any]) -> None:
+    try:
+        import matplotlib.pyplot as plt  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("matplotlib is required for PNG plots") from exc
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    labels = metrics["confusion_matrix"]["labels"]
+    matrix = metrics["confusion_matrix"]["matrix"]
+    fig, ax = plt.subplots(figsize=(max(4, len(labels)), max(4, len(labels))))
+    im = ax.imshow(matrix, cmap="Blues")
+    ax.set_xticks(range(len(labels)), labels=labels, rotation=45, ha="right")
+    ax.set_yticks(range(len(labels)), labels=labels)
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("Actual")
+    for row_index, row in enumerate(matrix):
+        for col_index, value in enumerate(row):
+            ax.text(col_index, row_index, str(value), ha="center", va="center")
+    fig.colorbar(im, ax=ax)
+    fig.tight_layout()
+    fig.savefig(output)
+    plt.close(fig)
+
+
+def plot_binary_curves(
+    roc_path: str | Path,
+    pr_path: str | Path,
+    predictions: list[dict[str, Any]],
+    *,
+    positive_label: str = "target",
+) -> None:
+    try:
+        import matplotlib.pyplot as plt  # type: ignore
+        from sklearn.metrics import precision_recall_curve, roc_curve  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("matplotlib and scikit-learn are required for ROC/PR plots") from exc
+
+    y_true: list[int] = []
+    y_score: list[float] = []
+    for row in predictions:
+        truth = row.get("ground_truth")
+        if truth is None:
+            continue
+        probabilities = _probabilities(row)
+        y_true.append(1 if str(truth) == positive_label else 0)
+        y_score.append(float(probabilities.get(positive_label, 0.0)))
+    if len(set(y_true)) < 2:
+        return
+
+    fpr, tpr, _ = roc_curve(y_true, y_score)
+    precision, recall, _ = precision_recall_curve(y_true, y_score)
+
+    _line_plot(roc_path, fpr, tpr, xlabel="False positive rate", ylabel="True positive rate", title="ROC Curve")
+    _line_plot(pr_path, recall, precision, xlabel="Recall", ylabel="Precision", title="PR Curve")
+
+
+def _line_plot(path: str | Path, x: Any, y: Any, *, xlabel: str, ylabel: str, title: str) -> None:
+    import matplotlib.pyplot as plt  # type: ignore
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(5, 4))
+    ax.plot(x, y)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(output)
+    plt.close(fig)
+
+
+def _probabilities(row: dict[str, Any]) -> dict[str, float]:
+    raw = row.get("probabilities_json")
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return {}
+    return {str(key): float(value) for key, value in data.items()}

--- a/src/wifi_id/evaluation/prequential.py
+++ b/src/wifi_id/evaluation/prequential.py
@@ -1,0 +1,65 @@
+"""Prequential test-then-train evaluation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from wifi_id.config import FeatureConfig
+from wifi_id.evaluation.metrics import classification_metrics
+from wifi_id.features.extract import row_to_model_features
+from wifi_id.models.base import OnlineModel
+from wifi_id.parsing.records import PredictionRow
+
+
+def evaluate_prequential_rows(
+    rows: Iterable[dict[str, Any]],
+    model: OnlineModel,
+    feature_config: FeatureConfig,
+    *,
+    label_column: str = "label",
+    positive_label: str = "target",
+    weight_column: str | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    y_true: list[str] = []
+    y_pred: list[str] = []
+    y_score: list[float] = []
+    predictions: list[dict[str, Any]] = []
+
+    for row in rows:
+        label = row.get(label_column)
+        if label is None:
+            continue
+        features = row_to_model_features(row, feature_config)
+        probabilities = model.predict_proba_one(features)
+        prediction = model.predict_one(features)
+        if prediction is None and probabilities:
+            prediction = max(probabilities, key=probabilities.get)
+        prediction = prediction or "__none__"
+        confidence = probabilities.get(prediction)
+        if confidence is None and probabilities:
+            confidence = max(probabilities.values())
+        y_true.append(str(label))
+        y_pred.append(str(prediction))
+        y_score.append(float(probabilities.get(positive_label, 0.0)))
+        predictions.append(
+            PredictionRow(
+                timestamp=row.get("timestamp"),
+                packet_index=int(row.get("packet_index") or len(predictions)),
+                label_mode=str(row.get("label_mode") or "unknown"),
+                predicted_class=str(prediction),
+                confidence=confidence,
+                ground_truth=str(label),
+                source_mac=row.get("source_mac"),
+                destination_mac=row.get("destination_mac"),
+                features_json=json.dumps(features, sort_keys=True),
+                probabilities_json=json.dumps(probabilities, sort_keys=True),
+            ).to_dict()
+        )
+        weight = None if weight_column is None else row.get(weight_column)
+        model.learn_one(features, str(label), None if weight is None else float(weight))
+
+    return (
+        classification_metrics(y_true, y_pred, y_score=y_score, positive_label=positive_label),
+        predictions,
+    )

--- a/src/wifi_id/evaluation/reports.py
+++ b/src/wifi_id/evaluation/reports.py
@@ -1,0 +1,82 @@
+"""Human-readable experiment reports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from wifi_id.config import AppConfig
+from wifi_id.models.registry import MODEL_MAPPINGS
+
+
+def write_markdown_report(
+    path: str | Path,
+    *,
+    config: AppConfig,
+    metrics: dict[str, Any],
+    title: str = "wifi-id Experiment Report",
+) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"# {title}",
+        "",
+        "## Summary",
+        "",
+        f"- Model: `{config.model.model_id}`",
+        f"- Label mode: `{config.labeling.mode}`",
+        f"- Examples: `{metrics.get('n_examples', 0)}`",
+        f"- Accuracy: `{_fmt(metrics.get('accuracy'))}`",
+        f"- Precision: `{_fmt(metrics.get('precision'))}`",
+        f"- Recall: `{_fmt(metrics.get('recall'))}`",
+        f"- F1: `{_fmt(metrics.get('f1'))}`",
+        f"- MCC: `{_fmt(metrics.get('mcc'))}`",
+        f"- ROC AUC: `{_fmt(metrics.get('roc_auc'))}`",
+        f"- PR AUC: `{_fmt(metrics.get('pr_auc'))}`",
+        "",
+        "## Model Mapping",
+        "",
+        f"`{config.model.model_id}` maps to `{MODEL_MAPPINGS.get(config.model.model_id, 'unknown')}`.",
+    ]
+    if config.features.leakage_debug:
+        lines.extend(
+            [
+                "",
+                "## Leakage Debug Warning",
+                "",
+                "This run included MAC-derived model features and should not be treated as a faithful reproduction run.",
+            ]
+        )
+    if _severe_skew(metrics):
+        lines.extend(
+            [
+                "",
+                "## Imbalance Warning",
+                "",
+                "The class distribution is severely skewed; accuracy is less informative than precision, recall, F1, MCC, ROC AUC, and PR AUC.",
+            ]
+        )
+    lines.extend(["", "## Per-Class Metrics", "", "| Class | Precision | Recall | F1 | Support |", "| --- | --- | --- | --- | --- |"])
+    for label, item in (metrics.get("per_class") or {}).items():
+        lines.append(
+            f"| `{label}` | {_fmt(item.get('precision'))} | {_fmt(item.get('recall'))} | {_fmt(item.get('f1'))} | {int(item.get('support', 0))} |"
+        )
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+def _severe_skew(metrics: dict[str, Any]) -> bool:
+    supports = [item.get("support", 0) for item in (metrics.get("per_class") or {}).values()]
+    if len(supports) < 2:
+        return False
+    smallest = min(supports)
+    largest = max(supports)
+    return bool(smallest and largest / smallest >= 10)
+

--- a/src/wifi_id/features/__init__.py
+++ b/src/wifi_id/features/__init__.py
@@ -1,0 +1,2 @@
+"""Feature extraction and model feature preparation."""
+

--- a/src/wifi_id/features/encoders.py
+++ b/src/wifi_id/features/encoders.py
@@ -1,0 +1,8 @@
+"""Compatibility wrappers for feature encoding."""
+
+from __future__ import annotations
+
+from wifi_id.features.extract import model_feature_names, row_to_model_features
+
+__all__ = ["model_feature_names", "row_to_model_features"]
+

--- a/src/wifi_id/features/extract.py
+++ b/src/wifi_id/features/extract.py
@@ -1,0 +1,130 @@
+"""Paper-based feature extraction."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Iterable, Iterator
+
+from wifi_id.config import FeatureConfig
+from wifi_id.parsing.records import FeatureRow, PacketRecord
+
+PAPER_FEATURES = [
+    "hour",
+    "data_rate",
+    "ssi",
+    "frame_type",
+    "frame_subtype",
+    "source_mac",
+    "destination_mac",
+    "data_size",
+]
+
+DEFAULT_MODEL_FEATURES = [
+    "hour",
+    "data_rate",
+    "ssi",
+    "frame_type",
+    "frame_subtype",
+    "data_size",
+]
+
+LEAKAGE_MODEL_FEATURES = ["source_mac", "destination_mac"]
+
+
+def choose_signal_value(row: dict[str, Any]) -> float | None:
+    value = row.get("ssi")
+    if value is None:
+        value = row.get("rssi")
+    return None if value is None else float(value)
+
+
+def choose_data_size(row: dict[str, Any], mode: str = "dot11_frame_len") -> int | None:
+    candidates: list[str]
+    if mode == "dot11_frame_len":
+        candidates = ["dot11_frame_len", "capture_len", "packet_len", "total_packet_len"]
+    elif mode == "payload_len":
+        candidates = ["payload_len", "dot11_frame_len", "capture_len", "packet_len"]
+    elif mode in {"packet_len", "total_packet_len"}:
+        candidates = ["packet_len", "total_packet_len", "capture_len"]
+    elif mode == "capture_len":
+        candidates = ["capture_len", "packet_len", "total_packet_len"]
+    else:
+        candidates = [mode, "dot11_frame_len", "capture_len", "packet_len", "total_packet_len"]
+
+    for key in candidates:
+        value = row.get(key)
+        if value is not None:
+            return int(value)
+    return None
+
+
+def record_to_feature_row(record: PacketRecord | dict[str, Any], config: FeatureConfig) -> FeatureRow:
+    row = record.to_dict() if isinstance(record, PacketRecord) else dict(record)
+    return FeatureRow(
+        timestamp=row.get("timestamp"),
+        source_file=str(row.get("source_file") or ""),
+        packet_index=int(row.get("packet_index") or 0),
+        hour=row.get("hour"),
+        data_rate=row.get("data_rate"),
+        ssi=choose_signal_value(row),
+        frame_type=row.get("frame_type"),
+        frame_subtype=row.get("frame_subtype"),
+        source_mac=row.get("source_mac"),
+        destination_mac=row.get("destination_mac"),
+        data_size=choose_data_size(row, config.data_size_mode),
+        total_packet_len=row.get("packet_len") or row.get("total_packet_len"),
+        dot11_frame_len=row.get("dot11_frame_len"),
+        payload_len=row.get("payload_len"),
+        channel_frequency=row.get("channel_frequency"),
+        retry=row.get("retry"),
+        protected=row.get("protected"),
+    )
+
+
+def iter_feature_rows(
+    records: Iterable[PacketRecord | dict[str, Any]],
+    config: FeatureConfig,
+) -> Iterator[dict[str, Any]]:
+    for record in records:
+        yield record_to_feature_row(record, config).to_dict()
+
+
+def model_feature_names(config: FeatureConfig) -> list[str]:
+    names = list(DEFAULT_MODEL_FEATURES)
+    if config.leakage_debug:
+        if config.mac_encoding == "hashed":
+            names.extend(["source_mac_hash", "destination_mac_hash"])
+        else:
+            names.extend(LEAKAGE_MODEL_FEATURES)
+    return names
+
+
+def row_to_model_features(row: dict[str, Any], config: FeatureConfig) -> dict[str, Any]:
+    features: dict[str, Any] = {}
+    for name in DEFAULT_MODEL_FEATURES:
+        value = row.get(name)
+        if value is None:
+            features[name] = config.impute_numeric if name in {"hour", "data_rate", "ssi", "data_size"} else config.impute_categorical
+            if config.include_missing_indicators:
+                features[f"{name}__missing"] = 1
+        else:
+            features[name] = value
+            if config.include_missing_indicators:
+                features[f"{name}__missing"] = 0
+
+    if config.leakage_debug:
+        if config.mac_encoding == "hashed":
+            features["source_mac_hash"] = stable_mac_hash(row.get("source_mac"))
+            features["destination_mac_hash"] = stable_mac_hash(row.get("destination_mac"))
+        else:
+            features["source_mac"] = row.get("source_mac") or config.impute_categorical
+            features["destination_mac"] = row.get("destination_mac") or config.impute_categorical
+    return features
+
+
+def stable_mac_hash(mac: str | None) -> str:
+    if not mac:
+        return "missing"
+    digest = hashlib.sha256(str(mac).lower().encode("utf-8")).hexdigest()
+    return digest[:16]
+

--- a/src/wifi_id/features/selection.py
+++ b/src/wifi_id/features/selection.py
@@ -1,0 +1,104 @@
+"""Information-gain-like feature ranking."""
+
+from __future__ import annotations
+
+import math
+import random
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+from wifi_id.data.readers import iter_rows
+from wifi_id.data.writers import write_json
+from wifi_id.features.extract import DEFAULT_MODEL_FEATURES
+
+
+def rank_feature_file(
+    input_path: str | Path,
+    *,
+    label_column: str = "label",
+    features: list[str] | None = None,
+    sample_size: int | None = None,
+    seed: int = 42,
+    output_json: str | Path | None = None,
+    output_markdown: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    rows = list(_sample_rows(iter_rows(input_path), sample_size=sample_size, seed=seed))
+    feature_names = features or [name for name in DEFAULT_MODEL_FEATURES if rows and name in rows[0]]
+    ranked = [
+        {"feature": feature, "score": mutual_information(rows, feature, label_column)}
+        for feature in feature_names
+    ]
+    ranked.sort(key=lambda item: item["score"], reverse=True)
+    if output_json is not None:
+        write_json(output_json, {"features": ranked})
+    if output_markdown is not None:
+        write_feature_ranking_markdown(output_markdown, ranked)
+    return ranked
+
+
+def mutual_information(rows: list[dict[str, Any]], feature: str, label_column: str) -> float:
+    pair_counts: Counter[tuple[str, str]] = Counter()
+    feature_counts: Counter[str] = Counter()
+    label_counts: Counter[str] = Counter()
+
+    for row in rows:
+        label = row.get(label_column)
+        if label is None:
+            continue
+        value = _bucket_value(row.get(feature))
+        label_text = str(label)
+        pair_counts[(value, label_text)] += 1
+        feature_counts[value] += 1
+        label_counts[label_text] += 1
+
+    total = sum(pair_counts.values())
+    if total == 0:
+        return 0.0
+
+    score = 0.0
+    for (value, label), pair_count in pair_counts.items():
+        p_xy = pair_count / total
+        p_x = feature_counts[value] / total
+        p_y = label_counts[label] / total
+        score += p_xy * math.log(p_xy / (p_x * p_y), 2)
+    return score
+
+
+def write_feature_ranking_markdown(path: str | Path, ranked: list[dict[str, Any]]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["# Feature Ranking", "", "| Rank | Feature | Score |", "| --- | --- | --- |"]
+    for index, item in enumerate(ranked, start=1):
+        lines.append(f"| {index} | `{item['feature']}` | {item['score']:.6f} |")
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _sample_rows(
+    rows: Iterable[dict[str, Any]],
+    *,
+    sample_size: int | None,
+    seed: int,
+) -> list[dict[str, Any]]:
+    if sample_size is None:
+        return list(rows)
+    rng = random.Random(seed)
+    reservoir: list[dict[str, Any]] = []
+    for index, row in enumerate(rows, start=1):
+        if len(reservoir) < sample_size:
+            reservoir.append(row)
+            continue
+        replace_index = rng.randrange(index)
+        if replace_index < sample_size:
+            reservoir[replace_index] = row
+    return reservoir
+
+
+def _bucket_value(value: Any) -> str:
+    if value is None:
+        return "missing"
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "missing"
+        return f"{value:.3g}"
+    return str(value)

--- a/src/wifi_id/inference/__init__.py
+++ b/src/wifi_id/inference/__init__.py
@@ -1,0 +1,2 @@
+"""Classification and rolling aggregation."""
+

--- a/src/wifi_id/inference/aggregate.py
+++ b/src/wifi_id/inference/aggregate.py
@@ -1,0 +1,121 @@
+"""Rolling target-presence aggregation."""
+
+from __future__ import annotations
+
+import json
+from statistics import mean
+from typing import Any, Iterable
+
+from wifi_id.config import WindowConfig
+from wifi_id.parsing.records import RollingPresenceRow
+
+
+def rolling_frame_count(
+    predictions: Iterable[dict[str, Any]],
+    *,
+    target_class: str,
+    config: WindowConfig,
+) -> list[dict[str, Any]]:
+    rows = list(predictions)
+    output: list[dict[str, Any]] = []
+    for start in range(0, len(rows), config.frame_count):
+        chunk = rows[start : start + config.frame_count]
+        if chunk:
+            output.append(_summarize_window(chunk, start, start + len(chunk) - 1, target_class, config))
+    return output
+
+
+def rolling_time(
+    predictions: Iterable[dict[str, Any]],
+    *,
+    target_class: str,
+    config: WindowConfig,
+) -> list[dict[str, Any]]:
+    buckets: dict[int, list[dict[str, Any]]] = {}
+    for row in predictions:
+        timestamp = row.get("timestamp")
+        if timestamp is None:
+            continue
+        bucket = int(float(timestamp) // config.time_seconds)
+        buckets.setdefault(bucket, []).append(row)
+    output = []
+    for bucket, rows in sorted(buckets.items()):
+        start = bucket * config.time_seconds
+        end = start + config.time_seconds
+        output.append(_summarize_window(rows, start, end, target_class, config))
+    return output
+
+
+def rolling_aggregates(
+    predictions: Iterable[dict[str, Any]],
+    *,
+    target_class: str,
+    config: WindowConfig,
+) -> list[dict[str, Any]]:
+    rows = list(predictions)
+    frame_rows = rolling_frame_count(rows, target_class=target_class, config=config)
+    for row in frame_rows:
+        row["window_type"] = "frame_count"
+    time_rows = rolling_time(rows, target_class=target_class, config=config)
+    for row in time_rows:
+        row["window_type"] = "time"
+    return frame_rows + time_rows
+
+
+def _summarize_window(
+    rows: list[dict[str, Any]],
+    window_start: float | int,
+    window_end: float | int,
+    target_class: str,
+    config: WindowConfig,
+) -> dict[str, Any]:
+    probabilities = [_target_probability(row, target_class) for row in rows]
+    positives = [row for row in rows if row.get("predicted_class") == target_class]
+    positive_ratio = len(positives) / len(rows) if rows else None
+    mean_probability = mean(probabilities) if probabilities else None
+    max_probability = max(probabilities) if probabilities else None
+    state = _presence_state(len(rows), positive_ratio, mean_probability, max_probability, config)
+    return RollingPresenceRow(
+        window_start=window_start,
+        window_end=window_end,
+        target_id=target_class,
+        frame_count=len(rows),
+        mean_probability=mean_probability,
+        max_probability=max_probability,
+        positive_prediction_ratio=positive_ratio,
+        state=state,
+    ).to_dict()
+
+
+def _target_probability(row: dict[str, Any], target_class: str) -> float:
+    raw = row.get("probabilities_json")
+    if raw:
+        try:
+            probabilities = json.loads(raw)
+            if target_class in probabilities:
+                return float(probabilities[target_class])
+        except Exception:
+            pass
+    if row.get("predicted_class") == target_class:
+        return float(row.get("confidence") or 1.0)
+    return 0.0
+
+
+def _presence_state(
+    frame_count: int,
+    positive_ratio: float | None,
+    mean_probability: float | None,
+    max_probability: float | None,
+    config: WindowConfig,
+) -> str:
+    if frame_count < config.min_frames:
+        return "uncertain"
+    ratio_ok = positive_ratio is not None and positive_ratio >= config.present_ratio_threshold
+    mean_ok = mean_probability is not None and mean_probability >= config.mean_probability_threshold
+    max_ok = max_probability is not None and max_probability >= config.max_probability_threshold
+    if ratio_ok and (mean_ok or max_ok):
+        return "present"
+    if not ratio_ok and not mean_ok and not max_ok:
+        return "absent"
+    return "uncertain"
+

--- a/src/wifi_id/inference/checkpoints.py
+++ b/src/wifi_id/inference/checkpoints.py
@@ -1,0 +1,6 @@
+"""Checkpoint helpers."""
+
+from wifi_id.models.base import load_checkpoint, save_checkpoint
+
+__all__ = ["load_checkpoint", "save_checkpoint"]
+

--- a/src/wifi_id/inference/classify.py
+++ b/src/wifi_id/inference/classify.py
@@ -1,0 +1,49 @@
+"""Offline row classification."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from wifi_id.config import FeatureConfig
+from wifi_id.features.extract import row_to_model_features
+from wifi_id.models.base import OnlineModel
+from wifi_id.parsing.records import PredictionRow
+
+
+def classify_rows(
+    rows: Iterable[dict[str, Any]],
+    model: OnlineModel,
+    feature_config: FeatureConfig,
+    *,
+    label_mode: str = "unknown",
+    label_column: str = "label",
+    positive_label: str = "target",
+) -> list[dict[str, Any]]:
+    predictions: list[dict[str, Any]] = []
+    for row in rows:
+        features = row_to_model_features(row, feature_config)
+        probabilities = model.predict_proba_one(features)
+        prediction = model.predict_one(features)
+        if prediction is None and probabilities:
+            prediction = max(probabilities, key=probabilities.get)
+        prediction = prediction or "__none__"
+        confidence = probabilities.get(prediction)
+        if confidence is None and probabilities:
+            confidence = max(probabilities.values())
+        predictions.append(
+            PredictionRow(
+                timestamp=row.get("timestamp"),
+                packet_index=int(row.get("packet_index") or len(predictions)),
+                label_mode=str(row.get("label_mode") or label_mode),
+                predicted_class=str(prediction),
+                confidence=confidence,
+                ground_truth=None if row.get(label_column) is None else str(row.get(label_column)),
+                source_mac=row.get("source_mac"),
+                destination_mac=row.get("destination_mac"),
+                features_json=json.dumps(features, sort_keys=True),
+                probabilities_json=json.dumps(probabilities, sort_keys=True),
+            ).to_dict()
+        )
+    return predictions
+

--- a/src/wifi_id/labeling/__init__.py
+++ b/src/wifi_id/labeling/__init__.py
@@ -1,0 +1,2 @@
+"""Target registries, labelers, and filters."""
+

--- a/src/wifi_id/labeling/filters.py
+++ b/src/wifi_id/labeling/filters.py
@@ -1,0 +1,73 @@
+"""Dataset filtering helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from wifi_id.config import FilterConfig
+from wifi_id.labeling.targets import TargetRegistry
+from wifi_id.parsing.dot11 import frame_family, normalize_mac
+
+
+def passes_filters(
+    row: dict[str, Any],
+    config: FilterConfig,
+    *,
+    registry: TargetRegistry | None = None,
+) -> bool:
+    if config.known_targets_only:
+        if registry is None or registry.target_for_mac(row.get("source_mac")) is None:
+            return False
+
+    family = frame_family(row.get("frame_type"))
+    if family == "management" and not config.include_management:
+        return False
+    if family == "control" and not config.include_control:
+        return False
+    if family == "data" and not config.include_data:
+        return False
+
+    if not config.include_ap_originated and is_ap_originated(row, config):
+        return False
+
+    if config.channel_frequency is not None and row.get("channel_frequency") != config.channel_frequency:
+        return False
+
+    timestamp = row.get("timestamp")
+    if config.start_time is not None and timestamp is not None:
+        if float(timestamp) < _parse_time(config.start_time):
+            return False
+    if config.end_time is not None and timestamp is not None:
+        if float(timestamp) > _parse_time(config.end_time):
+            return False
+
+    signal = row.get("rssi")
+    if signal is None:
+        signal = row.get("ssi")
+    if config.rssi_min is not None and signal is not None and float(signal) < config.rssi_min:
+        return False
+    if config.rssi_max is not None and signal is not None and float(signal) > config.rssi_max:
+        return False
+
+    frame_size = row.get("data_size") or row.get("dot11_frame_len") or row.get("packet_len")
+    if config.min_frame_size is not None and frame_size is not None:
+        if int(frame_size) < config.min_frame_size:
+            return False
+
+    return True
+
+
+def is_ap_originated(row: dict[str, Any], config: FilterConfig) -> bool:
+    source = normalize_mac(row.get("source_mac"))
+    ap_macs = {normalize_mac(mac) for mac in config.ap_macs}
+    if source is not None and source in ap_macs:
+        return True
+    return bool(row.get("from_ds")) and not bool(row.get("to_ds"))
+
+
+def _parse_time(value: float | str) -> float:
+    if isinstance(value, (float, int)):
+        return float(value)
+    return datetime.fromisoformat(value).timestamp()
+

--- a/src/wifi_id/labeling/labelers.py
+++ b/src/wifi_id/labeling/labelers.py
@@ -1,0 +1,51 @@
+"""Label assignment strategies."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Iterator
+
+from wifi_id.config import LabelConfig
+from wifi_id.labeling.targets import TargetRegistry
+
+
+def label_for_row(
+    row: dict[str, Any],
+    registry: TargetRegistry,
+    config: LabelConfig,
+) -> str | None:
+    source_target_id = registry.target_id_for_mac(row.get("source_mac"))
+
+    if config.mode == "binary_one_vs_rest":
+        if config.target_id is None:
+            return config.positive_label if source_target_id is not None else config.negative_label
+        return config.positive_label if source_target_id == config.target_id else config.negative_label
+
+    if config.mode == "per_target_binary":
+        if config.target_id is None:
+            raise ValueError("per_target_binary requires labeling.target_id")
+        return config.positive_label if source_target_id == config.target_id else config.negative_label
+
+    if config.mode == "multiclass_known_targets_only":
+        return source_target_id
+
+    if config.mode == "multiclass_with_other":
+        return source_target_id or config.negative_label
+
+    raise ValueError(f"Unsupported label mode: {config.mode}")
+
+
+def iter_labeled_rows(
+    rows: Iterable[dict[str, Any]],
+    registry: TargetRegistry,
+    config: LabelConfig,
+) -> Iterator[dict[str, Any]]:
+    for row in rows:
+        label = label_for_row(row, registry, config)
+        if label is None:
+            continue
+        output = dict(row)
+        output["label"] = label
+        output["source_target_id"] = registry.target_id_for_mac(row.get("source_mac"))
+        output["label_mode"] = config.mode
+        yield output
+

--- a/src/wifi_id/labeling/targets.py
+++ b/src/wifi_id/labeling/targets.py
@@ -1,0 +1,70 @@
+"""Target registry loading and MAC matching."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from wifi_id.parsing.dot11 import normalize_mac
+
+
+@dataclass(frozen=True)
+class Target:
+    target_id: str
+    label: str | None
+    mac_addresses: tuple[str, ...]
+    enabled: bool = True
+
+
+class TargetRegistry:
+    def __init__(self, targets: list[Target]) -> None:
+        self.targets = targets
+        self._mac_to_target: dict[str, Target] = {}
+        for target in targets:
+            if not target.enabled:
+                continue
+            for mac in target.mac_addresses:
+                normalized = normalize_mac(mac)
+                if normalized is not None:
+                    self._mac_to_target[normalized] = target
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "TargetRegistry":
+        registry_path = Path(path)
+        with registry_path.open("r", encoding="utf-8") as handle:
+            if registry_path.suffix.lower() == ".json":
+                data = json.load(handle)
+            else:
+                data = yaml.safe_load(handle) or {}
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TargetRegistry":
+        targets = []
+        for raw in data.get("targets", []):
+            targets.append(
+                Target(
+                    target_id=str(raw["target_id"]),
+                    label=raw.get("label"),
+                    mac_addresses=tuple(normalize_mac(mac) or "" for mac in raw.get("mac_addresses", [])),
+                    enabled=bool(raw.get("enabled", True)),
+                )
+            )
+        return cls(targets)
+
+    def target_for_mac(self, mac: str | None) -> Target | None:
+        normalized = normalize_mac(mac)
+        if normalized is None:
+            return None
+        return self._mac_to_target.get(normalized)
+
+    def target_id_for_mac(self, mac: str | None) -> str | None:
+        target = self.target_for_mac(mac)
+        return None if target is None else target.target_id
+
+    def enabled_target_ids(self) -> set[str]:
+        return {target.target_id for target in self.targets if target.enabled}

--- a/src/wifi_id/models/__init__.py
+++ b/src/wifi_id/models/__init__.py
@@ -1,0 +1,6 @@
+"""Online model registry."""
+
+from wifi_id.models.registry import MODEL_MAPPINGS, create_model
+
+__all__ = ["MODEL_MAPPINGS", "create_model"]
+

--- a/src/wifi_id/models/base.py
+++ b/src/wifi_id/models/base.py
@@ -1,0 +1,69 @@
+"""Common online classifier wrapper and checkpoint format."""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CHECKPOINT_VERSION = 1
+
+
+@dataclass
+class OnlineModel:
+    model_id: str
+    estimator: Any
+    feature_names: list[str]
+    metadata: dict[str, Any]
+
+    def predict_one(self, features: dict[str, Any]) -> str | None:
+        prediction = self.estimator.predict_one(features)
+        return None if prediction is None else str(prediction)
+
+    def predict_proba_one(self, features: dict[str, Any]) -> dict[str, float]:
+        if not hasattr(self.estimator, "predict_proba_one"):
+            return {}
+        probabilities = self.estimator.predict_proba_one(features) or {}
+        return {str(label): float(value) for label, value in probabilities.items()}
+
+    def learn_one(self, features: dict[str, Any], label: str, weight: float | None = None) -> None:
+        if weight is None:
+            self.estimator.learn_one(features, label)
+            return
+        try:
+            self.estimator.learn_one(features, label, w=weight)
+        except TypeError:
+            self.estimator.learn_one(features, label)
+
+    def save(self, path: str | Path) -> None:
+        save_checkpoint(path, self)
+
+
+def save_checkpoint(path: str | Path, model: OnlineModel) -> None:
+    checkpoint_path = Path(path)
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": CHECKPOINT_VERSION,
+        "model_id": model.model_id,
+        "feature_names": model.feature_names,
+        "metadata": model.metadata,
+        "estimator": model.estimator,
+    }
+    with checkpoint_path.open("wb") as handle:
+        pickle.dump(payload, handle)
+
+
+def load_checkpoint(path: str | Path) -> OnlineModel:
+    with Path(path).open("rb") as handle:
+        payload = pickle.load(handle)
+    version = payload.get("version")
+    if version != CHECKPOINT_VERSION:
+        raise ValueError(f"Unsupported checkpoint version: {version}")
+    return OnlineModel(
+        model_id=payload["model_id"],
+        estimator=payload["estimator"],
+        feature_names=list(payload["feature_names"]),
+        metadata=dict(payload.get("metadata") or {}),
+    )
+

--- a/src/wifi_id/models/registry.py
+++ b/src/wifi_id/models/registry.py
@@ -1,0 +1,72 @@
+"""Application model IDs mapped to native Python streaming estimators."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from wifi_id.models.base import OnlineModel
+
+MODEL_MAPPINGS = {
+    "leveraging_bag": "river.ensemble.LeveragingBaggingClassifier(HoeffdingTreeClassifier)",
+    "oza_boost": "river.ensemble.AdaBoostClassifier(HoeffdingTreeClassifier)",
+    "oza_boost_adwin": "river.ensemble.ADWINBoostingClassifier(HoeffdingTreeClassifier), falling back to ADWINBaggingClassifier when unavailable",
+    "adaptive_hoeffding_tree": "river.tree.HoeffdingAdaptiveTreeClassifier",
+}
+
+
+def create_model(
+    model_id: str,
+    *,
+    feature_names: list[str],
+    seed: int = 42,
+    params: dict[str, Any] | None = None,
+) -> OnlineModel:
+    try:
+        from river import ensemble, tree  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("river is required for online model training") from exc
+
+    params = dict(params or {})
+    base_params = dict(params.pop("base_model", {}))
+    n_models = int(params.pop("n_models", 10))
+
+    if model_id == "adaptive_hoeffding_tree":
+        estimator = tree.HoeffdingAdaptiveTreeClassifier(seed=seed, **params)
+    elif model_id == "leveraging_bag":
+        base = tree.HoeffdingTreeClassifier(**base_params)
+        estimator = ensemble.LeveragingBaggingClassifier(
+            model=base,
+            n_models=n_models,
+            seed=seed,
+            **params,
+        )
+    elif model_id == "oza_boost":
+        base = tree.HoeffdingTreeClassifier(**base_params)
+        estimator = ensemble.AdaBoostClassifier(model=base, n_models=n_models, seed=seed, **params)
+    elif model_id == "oza_boost_adwin":
+        base = tree.HoeffdingTreeClassifier(**base_params)
+        if hasattr(ensemble, "ADWINBoostingClassifier"):
+            estimator = ensemble.ADWINBoostingClassifier(
+                model=base,
+                n_models=n_models,
+                seed=seed,
+                **params,
+            )
+        elif hasattr(ensemble, "ADWINBaggingClassifier"):
+            estimator = ensemble.ADWINBaggingClassifier(
+                model=base,
+                n_models=n_models,
+                seed=seed,
+                **params,
+            )
+        else:
+            raise RuntimeError("The installed river version provides no ADWIN ensemble classifier")
+    else:
+        raise ValueError(f"Unsupported model_id: {model_id}")
+
+    return OnlineModel(
+        model_id=model_id,
+        estimator=estimator,
+        feature_names=feature_names,
+        metadata={"mapping": MODEL_MAPPINGS[model_id], "seed": seed},
+    )

--- a/src/wifi_id/parsing/__init__.py
+++ b/src/wifi_id/parsing/__init__.py
@@ -1,0 +1,2 @@
+"""Packet parsing helpers."""
+

--- a/src/wifi_id/parsing/dot11.py
+++ b/src/wifi_id/parsing/dot11.py
@@ -1,0 +1,194 @@
+"""802.11 MAC-header extraction and address-role mapping."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from wifi_id.parsing.records import PacketRecord
+
+
+FRAME_FAMILY_BY_TYPE = {
+    0: "management",
+    1: "control",
+    2: "data",
+    3: "extension",
+}
+
+
+def normalize_mac(mac: str | None) -> str | None:
+    if mac is None:
+        return None
+    value = str(mac).strip().lower()
+    if not value or value in {"none", "00:00:00:00:00:00"}:
+        return None
+    return value
+
+
+def map_logical_addresses(
+    to_ds: bool,
+    from_ds: bool,
+    addr1: str | None,
+    addr2: str | None,
+    addr3: str | None,
+    addr4: str | None = None,
+) -> tuple[str | None, str | None]:
+    """Map physical 802.11 address fields to logical source and destination."""
+    a1 = normalize_mac(addr1)
+    a2 = normalize_mac(addr2)
+    a3 = normalize_mac(addr3)
+    a4 = normalize_mac(addr4)
+
+    if not to_ds and not from_ds:
+        return a2, a1
+    if to_ds and not from_ds:
+        return a2, a3
+    if not to_ds and from_ds:
+        return a3, a1
+    return a4, a3
+
+
+def frame_family(frame_type: int | None) -> str | None:
+    if frame_type is None:
+        return None
+    return FRAME_FAMILY_BY_TYPE.get(int(frame_type), "unknown")
+
+
+def _packet_len(packet: Any) -> int | None:
+    try:
+        return len(bytes(packet))
+    except Exception:
+        return None
+
+
+def _hour_from_timestamp(timestamp: float | None) -> int | None:
+    if timestamp is None:
+        return None
+    return datetime.fromtimestamp(float(timestamp)).hour
+
+
+def _flag_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except Exception:
+        return 0
+
+
+def extract_dot11_fields(packet: Any) -> dict[str, Any]:
+    """Extract Dot11 fields from a Scapy packet.
+
+    The import is intentionally local so non-packet utilities can be imported
+    without Scapy installed.
+    """
+    try:
+        from scapy.layers.dot11 import Dot11  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("Scapy is required for Dot11 parsing") from exc
+
+    if not packet.haslayer(Dot11):
+        raise ValueError("packet has no 802.11 Dot11 layer")
+
+    dot11 = packet[Dot11]
+    fc = _flag_int(getattr(dot11, "FCfield", 0))
+    to_ds = bool(fc & 0x01)
+    from_ds = bool(fc & 0x02)
+    retry = bool(fc & 0x08)
+    protected = bool(fc & 0x40)
+    addr1 = normalize_mac(getattr(dot11, "addr1", None))
+    addr2 = normalize_mac(getattr(dot11, "addr2", None))
+    addr3 = normalize_mac(getattr(dot11, "addr3", None))
+    addr4 = normalize_mac(getattr(dot11, "addr4", None))
+    source, destination = map_logical_addresses(to_ds, from_ds, addr1, addr2, addr3, addr4)
+    sc = getattr(dot11, "SC", None)
+    sequence_number = None if sc is None else int(sc) >> 4
+
+    try:
+        payload_len = len(bytes(dot11.payload))
+    except Exception:
+        payload_len = None
+
+    return {
+        "frame_type": getattr(dot11, "type", None),
+        "frame_subtype": getattr(dot11, "subtype", None),
+        "to_ds": to_ds,
+        "from_ds": from_ds,
+        "addr1": addr1,
+        "addr2": addr2,
+        "addr3": addr3,
+        "addr4": addr4,
+        "source_mac": source,
+        "destination_mac": destination,
+        "sequence_number": sequence_number,
+        "retry": retry,
+        "protected": protected,
+        "payload_len": payload_len,
+    }
+
+
+def parse_packet_to_record(
+    packet: Any,
+    source_file: str,
+    packet_index: int,
+    radiotap_fields: dict[str, Any],
+) -> PacketRecord:
+    timestamp = getattr(packet, "time", None)
+    timestamp_value = None if timestamp is None else float(timestamp)
+    packet_len = _packet_len(packet)
+    capture_len = len(getattr(packet, "original", b"") or b"") or packet_len
+    original_len = getattr(packet, "wirelen", None) or packet_len
+    radiotap_len = radiotap_fields.get("radiotap_len")
+
+    try:
+        dot11_fields = extract_dot11_fields(packet)
+    except Exception as exc:
+        return PacketRecord(
+            timestamp=timestamp_value,
+            source_file=source_file,
+            packet_index=packet_index,
+            packet_len=packet_len,
+            capture_len=capture_len,
+            original_len=original_len,
+            radiotap_len=radiotap_len,
+            hour=_hour_from_timestamp(timestamp_value),
+            data_rate=radiotap_fields.get("data_rate"),
+            channel_frequency=radiotap_fields.get("channel_frequency"),
+            ssi=radiotap_fields.get("ssi"),
+            rssi=radiotap_fields.get("rssi"),
+            parse_ok=False,
+            parse_error=str(exc),
+        )
+
+    dot11_frame_len = None
+    if packet_len is not None and radiotap_len is not None:
+        dot11_frame_len = max(int(packet_len) - int(radiotap_len), 0)
+
+    return PacketRecord(
+        timestamp=timestamp_value,
+        source_file=source_file,
+        packet_index=packet_index,
+        packet_len=packet_len,
+        capture_len=capture_len,
+        original_len=original_len,
+        radiotap_len=radiotap_len,
+        dot11_frame_len=dot11_frame_len,
+        payload_len=dot11_fields.get("payload_len"),
+        hour=_hour_from_timestamp(timestamp_value),
+        data_rate=radiotap_fields.get("data_rate"),
+        channel_frequency=radiotap_fields.get("channel_frequency"),
+        ssi=radiotap_fields.get("ssi"),
+        rssi=radiotap_fields.get("rssi"),
+        frame_type=dot11_fields.get("frame_type"),
+        frame_subtype=dot11_fields.get("frame_subtype"),
+        to_ds=dot11_fields.get("to_ds"),
+        from_ds=dot11_fields.get("from_ds"),
+        addr1=dot11_fields.get("addr1"),
+        addr2=dot11_fields.get("addr2"),
+        addr3=dot11_fields.get("addr3"),
+        addr4=dot11_fields.get("addr4"),
+        source_mac=dot11_fields.get("source_mac"),
+        destination_mac=dot11_fields.get("destination_mac"),
+        sequence_number=dot11_fields.get("sequence_number"),
+        retry=dot11_fields.get("retry"),
+        protected=dot11_fields.get("protected"),
+    )
+

--- a/src/wifi_id/parsing/radiotap.py
+++ b/src/wifi_id/parsing/radiotap.py
@@ -1,0 +1,40 @@
+"""Radiotap metadata extraction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_radiotap_fields_from_layer(layer: Any) -> dict[str, Any]:
+    """Extract the small Radiotap subset used by the application."""
+    data_rate = getattr(layer, "Rate", None)
+    channel_frequency = getattr(layer, "ChannelFrequency", None)
+    antenna_signal = getattr(layer, "dBm_AntSignal", None)
+    db_antenna_signal = getattr(layer, "dB_AntSignal", None)
+    radiotap_len = getattr(layer, "len", None)
+    return {
+        "radiotap_len": None if radiotap_len is None else int(radiotap_len),
+        "data_rate": None if data_rate is None else float(data_rate),
+        "channel_frequency": None if channel_frequency is None else int(channel_frequency),
+        "ssi": None if db_antenna_signal is None else float(db_antenna_signal),
+        "rssi": None if antenna_signal is None else float(antenna_signal),
+    }
+
+
+def extract_radiotap_fields(packet: Any) -> dict[str, Any]:
+    try:
+        from scapy.layers.dot11 import RadioTap  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("Scapy is required for Radiotap parsing") from exc
+
+    defaults = {
+        "radiotap_len": None,
+        "data_rate": None,
+        "channel_frequency": None,
+        "ssi": None,
+        "rssi": None,
+    }
+    if not packet.haslayer(RadioTap):
+        return defaults
+    return defaults | extract_radiotap_fields_from_layer(packet[RadioTap])
+

--- a/src/wifi_id/parsing/records.py
+++ b/src/wifi_id/parsing/records.py
@@ -1,0 +1,98 @@
+"""Stable row contracts shared across the pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass
+class PacketRecord:
+    timestamp: float | None
+    source_file: str
+    packet_index: int
+    packet_len: int | None = None
+    capture_len: int | None = None
+    original_len: int | None = None
+    radiotap_len: int | None = None
+    dot11_frame_len: int | None = None
+    payload_len: int | None = None
+    hour: int | None = None
+    data_rate: float | None = None
+    channel_frequency: int | None = None
+    ssi: float | None = None
+    rssi: float | None = None
+    frame_type: int | None = None
+    frame_subtype: int | None = None
+    to_ds: bool | None = None
+    from_ds: bool | None = None
+    addr1: str | None = None
+    addr2: str | None = None
+    addr3: str | None = None
+    addr4: str | None = None
+    source_mac: str | None = None
+    destination_mac: str | None = None
+    sequence_number: int | None = None
+    retry: bool | None = None
+    protected: bool | None = None
+    parse_ok: bool = True
+    parse_error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class FeatureRow:
+    timestamp: float | None
+    source_file: str
+    packet_index: int
+    hour: int | None
+    data_rate: float | None
+    ssi: float | None
+    frame_type: int | None
+    frame_subtype: int | None
+    source_mac: str | None
+    destination_mac: str | None
+    data_size: int | None
+    total_packet_len: int | None = None
+    dot11_frame_len: int | None = None
+    payload_len: int | None = None
+    channel_frequency: int | None = None
+    retry: bool | None = None
+    protected: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class PredictionRow:
+    timestamp: float | None
+    packet_index: int
+    label_mode: str
+    predicted_class: str | None
+    confidence: float | None
+    ground_truth: str | None
+    source_mac: str | None
+    destination_mac: str | None
+    features_json: str
+    probabilities_json: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RollingPresenceRow:
+    window_start: float | int
+    window_end: float | int
+    target_id: str
+    frame_count: int
+    mean_probability: float | None
+    max_probability: float | None
+    positive_prediction_ratio: float | None
+    state: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+from typer.testing import CliRunner
+
+from wifi_id.cli import app
+
+
+def test_cli_help_smoke():
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "ingest" in result.output
+    assert "eval-prequential" in result.output
+

--- a/tests/test_dot11_mapping.py
+++ b/tests/test_dot11_mapping.py
@@ -1,0 +1,17 @@
+from wifi_id.parsing.dot11 import frame_family, map_logical_addresses, normalize_mac
+
+
+def test_logical_address_mapping_by_ds_bits():
+    assert map_logical_addresses(False, False, "d", "s", "bssid") == ("s", "d")
+    assert map_logical_addresses(True, False, "ap", "client", "server") == ("client", "server")
+    assert map_logical_addresses(False, True, "client", "ap", "server") == ("server", "client")
+    assert map_logical_addresses(True, True, "ra", "ta", "da", "sa") == ("sa", "da")
+
+
+def test_mac_normalization_and_frame_family():
+    assert normalize_mac("AA:BB:CC:DD:EE:FF") == "aa:bb:cc:dd:ee:ff"
+    assert normalize_mac("00:00:00:00:00:00") is None
+    assert frame_family(0) == "management"
+    assert frame_family(1) == "control"
+    assert frame_family(2) == "data"
+

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,57 @@
+from wifi_id.config import FeatureConfig
+from wifi_id.features.extract import model_feature_names, record_to_feature_row, row_to_model_features
+from wifi_id.parsing.records import PacketRecord
+
+
+def test_feature_extraction_data_size_fallback_and_signal_choice():
+    record = PacketRecord(
+        timestamp=1.0,
+        source_file="x.pcap",
+        packet_index=7,
+        packet_len=128,
+        dot11_frame_len=None,
+        capture_len=120,
+        payload_len=42,
+        rssi=-55,
+        source_mac="aa:bb:cc:dd:ee:ff",
+        destination_mac="11:22:33:44:55:66",
+    )
+    feature = record_to_feature_row(record, FeatureConfig()).to_dict()
+    assert feature["data_size"] == 120
+    assert feature["ssi"] == -55.0
+
+
+def test_default_model_features_drop_mac_addresses():
+    config = FeatureConfig(leakage_debug=False)
+    row = {
+        "hour": 1,
+        "data_rate": 54.0,
+        "ssi": -50,
+        "frame_type": 2,
+        "frame_subtype": 8,
+        "data_size": 200,
+        "source_mac": "aa:bb:cc:dd:ee:ff",
+        "destination_mac": "11:22:33:44:55:66",
+    }
+    features = row_to_model_features(row, config)
+    assert "source_mac" not in features
+    assert "destination_mac" not in features
+    assert model_feature_names(config) == [
+        "hour",
+        "data_rate",
+        "ssi",
+        "frame_type",
+        "frame_subtype",
+        "data_size",
+    ]
+
+
+def test_leakage_debug_adds_hashed_mac_features():
+    config = FeatureConfig(leakage_debug=True, mac_encoding="hashed")
+    features = row_to_model_features(
+        {"source_mac": "aa:bb:cc:dd:ee:ff", "destination_mac": "11:22:33:44:55:66"},
+        config,
+    )
+    assert "source_mac_hash" in features
+    assert features["source_mac_hash"] != "aa:bb:cc:dd:ee:ff"
+

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -1,0 +1,36 @@
+from wifi_id.config import FilterConfig, LabelConfig
+from wifi_id.labeling.filters import is_ap_originated, passes_filters
+from wifi_id.labeling.labelers import label_for_row
+from wifi_id.labeling.targets import TargetRegistry
+
+
+def registry():
+    return TargetRegistry.from_dict(
+        {
+            "targets": [
+                {
+                    "target_id": "phone",
+                    "label": "phone",
+                    "mac_addresses": ["aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:00"],
+                    "enabled": True,
+                }
+            ]
+        }
+    )
+
+
+def test_binary_and_multiclass_label_modes():
+    reg = registry()
+    row = {"source_mac": "aa:bb:cc:dd:ee:00"}
+    assert label_for_row(row, reg, LabelConfig(mode="binary_one_vs_rest", target_id="phone")) == "target"
+    assert label_for_row(row, reg, LabelConfig(mode="multiclass_known_targets_only")) == "phone"
+    assert label_for_row({"source_mac": "00:11:22:33:44:55"}, reg, LabelConfig(mode="multiclass_known_targets_only")) is None
+    assert label_for_row({"source_mac": "00:11:22:33:44:55"}, reg, LabelConfig(mode="multiclass_with_other")) == "other"
+
+
+def test_ap_filter_heuristic_can_exclude_ap_originated_rows():
+    config = FilterConfig(include_ap_originated=False)
+    row = {"from_ds": True, "to_ds": False, "frame_type": 2}
+    assert is_ap_originated(row, config)
+    assert not passes_filters(row, config)
+

--- a/tests/test_metrics_prequential.py
+++ b/tests/test_metrics_prequential.py
@@ -1,0 +1,52 @@
+from wifi_id.config import FeatureConfig
+from wifi_id.evaluation.metrics import classification_metrics
+from wifi_id.evaluation.prequential import evaluate_prequential_rows
+from wifi_id.models.base import OnlineModel
+
+
+class RecordingEstimator:
+    def __init__(self):
+        self.events = []
+        self.learned = 0
+
+    def predict_proba_one(self, x):
+        self.events.append(("proba", self.learned))
+        return {"target": 0.9, "other": 0.1} if self.learned else {}
+
+    def predict_one(self, x):
+        self.events.append(("predict", self.learned))
+        return "target" if self.learned else None
+
+    def learn_one(self, x, y):
+        self.events.append(("learn", self.learned))
+        self.learned += 1
+
+
+def test_prequential_predicts_before_learning_current_row():
+    estimator = RecordingEstimator()
+    model = OnlineModel("fake", estimator, [], {})
+    metrics, predictions = evaluate_prequential_rows(
+        [
+            {"label": "target", "hour": 1, "data_rate": 1, "ssi": 1, "frame_type": 2, "frame_subtype": 0, "data_size": 10},
+            {"label": "target", "hour": 1, "data_rate": 1, "ssi": 1, "frame_type": 2, "frame_subtype": 0, "data_size": 10},
+        ],
+        model,
+        FeatureConfig(),
+    )
+    assert estimator.events[:3] == [("proba", 0), ("predict", 0), ("learn", 0)]
+    assert metrics["n_examples"] == 2
+    assert len(predictions) == 2
+
+
+def test_metrics_include_imbalance_metrics():
+    metrics = classification_metrics(
+        ["target", "target", "other", "other"],
+        ["target", "other", "other", "other"],
+        y_score=[0.9, 0.4, 0.2, 0.1],
+    )
+    assert metrics["accuracy"] == 0.75
+    assert metrics["precision"] == 1.0
+    assert metrics["recall"] == 0.5
+    assert metrics["f1"] > 0
+    assert metrics["mcc"] is not None
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+from wifi_id.models.base import load_checkpoint
+from wifi_id.models.registry import MODEL_MAPPINGS, create_model
+
+
+pytest.importorskip("river")
+
+
+def test_all_model_ids_instantiate_and_checkpoint(tmp_path: Path):
+    for model_id in MODEL_MAPPINGS:
+        model = create_model(model_id, feature_names=["x"], seed=1, params={"n_models": 2})
+        model.learn_one({"x": 1}, "target")
+        assert model.predict_one({"x": 1}) is not None
+        checkpoint = tmp_path / f"{model_id}.pkl"
+        model.save(checkpoint)
+        loaded = load_checkpoint(checkpoint)
+        assert loaded.model_id == model_id
+

--- a/tests/test_radiotap.py
+++ b/tests/test_radiotap.py
@@ -1,0 +1,19 @@
+from wifi_id.parsing.radiotap import extract_radiotap_fields_from_layer
+
+
+class FakeRadioTap:
+    len = 18
+    Rate = 54
+    ChannelFrequency = 2412
+    dBm_AntSignal = -48
+    dB_AntSignal = 32
+
+
+def test_extract_radiotap_fields_from_layer():
+    fields = extract_radiotap_fields_from_layer(FakeRadioTap())
+    assert fields["radiotap_len"] == 18
+    assert fields["data_rate"] == 54.0
+    assert fields["channel_frequency"] == 2412
+    assert fields["rssi"] == -48.0
+    assert fields["ssi"] == 32.0
+

--- a/tests/test_sampling_splits.py
+++ b/tests/test_sampling_splits.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from wifi_id.data.readers import read_all_rows
+from wifi_id.data.sampling import balance_file, random_sample_file
+from wifi_id.data.splits import chronological_split_file, holdout_split_file
+from wifi_id.data.writers import write_rows
+
+
+def rows():
+    return [
+        {"timestamp": 1, "label": "target", "value": 1},
+        {"timestamp": 2, "label": "target", "value": 2},
+        {"timestamp": 3, "label": "other", "value": 3},
+        {"timestamp": 4, "label": "other", "value": 4},
+        {"timestamp": 5, "label": "other", "value": 5},
+    ]
+
+
+def test_random_sample_is_deterministic(tmp_path: Path):
+    source = tmp_path / "source.csv"
+    out1 = tmp_path / "out1.csv"
+    out2 = tmp_path / "out2.csv"
+    write_rows(source, rows())
+    random_sample_file(source, out1, percentage=50, seed=123)
+    random_sample_file(source, out2, percentage=50, seed=123)
+    assert read_all_rows(out1) == read_all_rows(out2)
+
+
+def test_downsample_balance(tmp_path: Path):
+    source = tmp_path / "source.csv"
+    output = tmp_path / "balanced.csv"
+    write_rows(source, rows())
+    balance_file(source, output, strategy="downsample", seed=1)
+    balanced = read_all_rows(output)
+    assert sum(1 for row in balanced if row["label"] == "target") == 2
+    assert sum(1 for row in balanced if row["label"] == "other") == 2
+
+
+def test_chronological_and_holdout_splits(tmp_path: Path):
+    source = tmp_path / "source.csv"
+    train = tmp_path / "train.csv"
+    test = tmp_path / "test.csv"
+    write_rows(source, rows())
+    chronological_split_file(source, train, test, train_fraction=0.6)
+    assert [row["timestamp"] for row in read_all_rows(train)] == [1, 2, 3]
+    assert [row["timestamp"] for row in read_all_rows(test)] == [4, 5]
+
+    holdout_split_file(source, train, test, train_fraction=0.6, seed=99)
+    assert len(read_all_rows(train)) == 3
+    assert len(read_all_rows(test)) == 2
+


### PR DESCRIPTION
## Summary

Adds the initial `wifi-id` Python package and CLI for passive per-frame 802.11 device identification from Radiotap and MAC-header metadata.

## Changes

- Adds typed parsing, feature extraction, labeling, filtering, dataset utilities, online model wrappers, evaluation, inference, rolling aggregation, and reporting modules.
- Adds YAML example config, target registry example, README, packaging metadata, and CLI entrypoint.
- Adds tests for address mapping, Radiotap extraction, feature policy, labeling, sampling/splits, metrics, prequential ordering, models, and CLI help.

## Validation

- `.venv/bin/python -m pytest -q` -> 15 passed
- `.venv/bin/python -m compileall -q src tests` -> passed

## Notes

The repo was empty, so `main` was initialized with a minimal base commit before opening this implementation PR.