### PR TITLE
[codex] Add synthetic demo pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ peekabo report --config configs/example.yaml
 
 All commands accept a YAML config and targeted path/model overrides. Internal datasets are Parquet by default; CSV export is supported for interoperability.
 
+If `ingest` reports that no capture files were found, check that the configured `input.paths` exist and contain `.pcap`, `.pcapng`, or `.cap` files.
+
+## Try It With Synthetic Data
+
+The repository includes a generator for a tiny synthetic Radiotap/802.11 capture. It contains fake MAC addresses and fake frame metadata, so it is safe to use as a first-run demo.
+
+```bash
+python examples/generate_synthetic_capture.py
+peekabo ingest --config configs/synthetic-demo.yaml
+peekabo features --config configs/synthetic-demo.yaml
+peekabo label --config configs/synthetic-demo.yaml
+```
+
+The generated capture is written under `examples/captures/`, and pipeline outputs are written under `runs/`. Both locations are ignored by Git so real captures and generated datasets are not accidentally committed.
+
 ## Faithful Feature Policy
 
 The default pipeline preserves MAC addresses for labeling, filtering, reporting, and diagnostics, but drops `source_mac` and `destination_mac` from model features. This prevents trivial identity leakage. To run an explicit ablation or sanity check, set:

--- a/configs/synthetic-demo.yaml
+++ b/configs/synthetic-demo.yaml
@@ -1,0 +1,66 @@
+input:
+  paths:
+    - examples/captures/synthetic-demo.pcap
+  live_interface: null
+target_registry_path: configs/targets.yaml
+output_dir: runs/synthetic-demo
+random_seed: 42
+
+features:
+  data_size_mode: dot11_frame_len
+  leakage_debug: false
+  impute_numeric: -1.0
+  impute_categorical: missing
+
+labeling:
+  mode: binary_one_vs_rest
+  target_id: iphone_5_user1
+  positive_label: target
+  negative_label: other
+
+filters:
+  known_targets_only: false
+  include_ap_originated: true
+  include_management: true
+  include_control: true
+  include_data: true
+  channel_frequency: null
+  start_time: null
+  end_time: null
+  rssi_min: null
+  rssi_max: null
+  min_frame_size: null
+  ap_macs: []
+
+model:
+  model_id: leveraging_bag
+  checkpoint_path: runs/synthetic-demo/model.pkl
+  params:
+    n_models: 5
+
+data:
+  normalized_path: runs/synthetic-demo/records.parquet
+  features_path: runs/synthetic-demo/features.parquet
+  labeled_path: runs/synthetic-demo/labeled.parquet
+  train_path: runs/synthetic-demo/train.parquet
+  test_path: runs/synthetic-demo/test.parquet
+  predictions_path: runs/synthetic-demo/predictions.parquet
+  rolling_path: runs/synthetic-demo/rolling.parquet
+  metrics_path: runs/synthetic-demo/metrics.json
+
+sampling:
+  percentage: 100
+  balance_strategy: none
+  class_weight_column: sample_weight
+
+split:
+  train_fraction: 0.9
+  chronological: true
+
+windowing:
+  frame_count: 100
+  time_seconds: 30
+  min_frames: 5
+  present_ratio_threshold: 0.5
+  mean_probability_threshold: 0.5
+  max_probability_threshold: 0.8

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,14 @@
 # Examples
 
-Place monitor-mode PCAP or PCAPNG files under `examples/captures/`, then run:
+Generate a tiny synthetic Radiotap/802.11 capture:
 
 ```bash
-peekabo ingest --config configs/example.yaml
+python examples/generate_synthetic_capture.py
+peekabo ingest --config configs/synthetic-demo.yaml
+peekabo features --config configs/synthetic-demo.yaml
+peekabo label --config configs/synthetic-demo.yaml
 ```
 
-The repository intentionally does not include real wireless captures.
+The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git.
 
+For real authorized monitor-mode captures, place PCAP or PCAPNG files under `examples/captures/`, then point a config at them. The repository intentionally does not include real wireless captures.

--- a/examples/generate_synthetic_capture.py
+++ b/examples/generate_synthetic_capture.py
@@ -1,0 +1,29 @@
+"""Generate the synthetic capture used by the example config."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from peekabo.capture.synthetic import write_synthetic_capture  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT / "examples" / "captures" / "synthetic-demo.pcap",
+        help="Output PCAP path.",
+    )
+    args = parser.parse_args()
+    output = write_synthetic_capture(args.output)
+    print(f"Wrote synthetic capture to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/peekabo/capture/sources.py
+++ b/src/peekabo/capture/sources.py
@@ -36,6 +36,7 @@ def expand_input_paths(paths: Iterable[str | Path]) -> list[Path]:
 
 def _reader_for_path(path: Path) -> Any:
     try:
+        import scapy.layers.dot11  # noqa: F401  # type: ignore
         from scapy.utils import PcapNgReader, PcapReader  # type: ignore
     except Exception as exc:  # pragma: no cover - dependency availability
         raise RuntimeError("Scapy is required for PCAP ingestion") from exc

--- a/src/peekabo/capture/synthetic.py
+++ b/src/peekabo/capture/synthetic.py
@@ -1,0 +1,57 @@
+"""Synthetic 802.11 captures for examples and tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+AP_MAC = "66:55:44:33:22:11"
+IPHONE_MAC = "aa:bb:cc:dd:ee:ff"
+LG_TV_MAC = "11:22:33:44:55:66"
+UNKNOWN_MAC = "22:33:44:55:66:77"
+INTERNET_MAC = "ff:ff:ff:ff:ff:ff"
+
+
+def write_synthetic_capture(path: str | Path) -> Path:
+    """Write a tiny passive-safe Radiotap/Dot11 PCAP fixture."""
+    try:
+        from scapy.layers.dot11 import Dot11, RadioTap  # type: ignore
+        from scapy.packet import Raw  # type: ignore
+        from scapy.utils import wrpcap  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency availability
+        raise RuntimeError("Scapy is required to generate the synthetic capture") from exc
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    packet_specs = [
+        (IPHONE_MAC, INTERNET_MAC, -41, 24, 12),
+        (LG_TV_MAC, INTERNET_MAC, -55, 18, 24),
+        (UNKNOWN_MAC, INTERNET_MAC, -67, 12, 36),
+        (IPHONE_MAC, INTERNET_MAC, -44, 36, 48),
+        (LG_TV_MAC, INTERNET_MAC, -53, 24, 60),
+    ]
+    packets = []
+    for index, (source_mac, destination_mac, rssi, rate, payload_len) in enumerate(packet_specs):
+        packet = (
+            RadioTap(
+                present="Rate+Channel+dBm_AntSignal",
+                Rate=rate,
+                ChannelFrequency=2412,
+                ChannelFlags=0x00A0,
+                dBm_AntSignal=rssi,
+            )
+            / Dot11(
+                type=2,
+                subtype=0,
+                FCfield=0x41,
+                addr1=AP_MAC,
+                addr2=source_mac,
+                addr3=destination_mac,
+                SC=index << 4,
+            )
+            / Raw(bytes([index + 1]) * payload_len)
+        )
+        packet.time = 1_700_000_000 + index
+        packets.append(packet)
+
+    wrpcap(str(output), packets)
+    return output

--- a/src/peekabo/cli.py
+++ b/src/peekabo/cli.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from peekabo.capture.live import iter_live_records
-from peekabo.capture.sources import iter_packet_records
+from peekabo.capture.sources import expand_input_paths, iter_packet_records
 from peekabo.config import AppConfig, load_config, write_run_config
 from peekabo.data.readers import iter_rows
 from peekabo.data.sampling import balance_file, random_sample_file
@@ -44,12 +44,34 @@ def ingest(
     config: ConfigOption,
     input_path: Annotated[list[Path] | None, typer.Option("--input", "-i")] = None,
     output: Annotated[Path | None, typer.Option("--output", "-o")] = None,
+    allow_empty: Annotated[
+        bool,
+        typer.Option(
+            "--allow-empty",
+            help="Write an empty dataset when no capture files are found.",
+        ),
+    ] = False,
 ) -> None:
     cfg = load_config(config)
     paths = input_path or cfg.input.paths
+    capture_paths = expand_input_paths(paths)
+    if not capture_paths:
+        path_list = ", ".join(str(path) for path in paths) or "<none>"
+        message = (
+            "No capture files found for input path(s): "
+            f"{path_list}. Expected .pcap, .pcapng, or .cap files."
+        )
+        if not allow_empty:
+            typer.secho(f"{message} Use --allow-empty to write an empty dataset.", err=True)
+            raise typer.Exit(1)
+        typer.secho(f"{message} Writing empty dataset because --allow-empty was set.", err=True)
+
     output_path = output or cfg.data.normalized_path
     _write_run_config(cfg)
-    count = write_rows(output_path, (record.to_dict() for record in iter_packet_records(paths)))
+    count = write_rows(
+        output_path,
+        (record.to_dict() for record in iter_packet_records(capture_paths)),
+    )
     typer.echo(f"Wrote {count} normalized packet records to {output_path}")
 
 

--- a/tests/test_demo_pipeline.py
+++ b/tests/test_demo_pipeline.py
@@ -1,0 +1,148 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from peekabo.capture.synthetic import IPHONE_MAC, write_synthetic_capture
+from peekabo.cli import app
+from peekabo.config import FeatureConfig
+from peekabo.data.readers import read_all_rows
+from peekabo.features.extract import row_to_model_features
+
+pytest.importorskip("scapy")
+
+
+def test_synthetic_capture_cli_pipeline(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_demo_config(config_path, targets_path, capture_path, output_dir)
+
+    runner = CliRunner()
+    ingest_result = runner.invoke(app, ["ingest", "--config", str(config_path)])
+    assert ingest_result.exit_code == 0, ingest_result.output
+    feature_result = runner.invoke(app, ["features", "--config", str(config_path)])
+    assert feature_result.exit_code == 0, feature_result.output
+    label_result = runner.invoke(app, ["label", "--config", str(config_path)])
+    assert label_result.exit_code == 0, label_result.output
+
+    records = read_all_rows(output_dir / "records.csv")
+    features = read_all_rows(output_dir / "features.csv")
+    labels = read_all_rows(output_dir / "labeled.csv")
+    assert len(records) == 5
+    assert len(features) == 5
+    assert len(labels) == 5
+    assert {row["label"] for row in labels} == {"target", "other"}
+    assert any(row["source_mac"] == IPHONE_MAC for row in features)
+
+    model_features = row_to_model_features(features[0], FeatureConfig())
+    assert "source_mac" not in model_features
+    assert "destination_mac" not in model_features
+
+
+def test_synthetic_capture_ingest_works_in_fresh_process(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_demo_config(config_path, targets_path, capture_path, output_dir)
+
+    env = os.environ.copy()
+    repo_src = Path(__file__).resolve().parents[1] / "src"
+    env["PYTHONPATH"] = f"{repo_src}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    result = subprocess.run(
+        [sys.executable, "-m", "peekabo.cli", "ingest", "--config", str(config_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    records = read_all_rows(output_dir / "records.csv")
+    assert len(records) == 5
+    assert all(row["parse_ok"] for row in records)
+
+
+def test_ingest_warns_and_fails_when_no_capture_files(tmp_path: Path):
+    config_path = tmp_path / "empty.yaml"
+    output_path = tmp_path / "records.csv"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input": {"paths": [str(tmp_path / "missing-captures")], "live_interface": None},
+                "output_dir": str(tmp_path / "runs"),
+                "data": {"normalized_path": str(output_path)},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["ingest", "--config", str(config_path)])
+
+    assert result.exit_code == 1
+    assert "No capture files found" in result.output
+    assert not output_path.exists()
+
+
+def _write_demo_config(
+    config_path: Path,
+    targets_path: Path,
+    capture_path: Path,
+    output_dir: Path,
+) -> None:
+    targets_path.write_text(
+        yaml.safe_dump(
+            {
+                "targets": [
+                    {
+                        "target_id": "iphone_5_user1",
+                        "label": "phone",
+                        "mac_addresses": [IPHONE_MAC],
+                        "enabled": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input": {"paths": [str(capture_path)], "live_interface": None},
+                "target_registry_path": str(targets_path),
+                "output_dir": str(output_dir),
+                "random_seed": 42,
+                "features": {
+                    "data_size_mode": "dot11_frame_len",
+                    "leakage_debug": False,
+                    "impute_numeric": -1.0,
+                    "impute_categorical": "missing",
+                },
+                "labeling": {
+                    "mode": "binary_one_vs_rest",
+                    "target_id": "iphone_5_user1",
+                    "positive_label": "target",
+                    "negative_label": "other",
+                },
+                "data": {
+                    "normalized_path": str(output_dir / "records.csv"),
+                    "features_path": str(output_dir / "features.csv"),
+                    "labeled_path": str(output_dir / "labeled.csv"),
+                    "train_path": str(output_dir / "train.csv"),
+                    "test_path": str(output_dir / "test.csv"),
+                    "predictions_path": str(output_dir / "predictions.csv"),
+                    "rolling_path": str(output_dir / "rolling.csv"),
+                    "metrics_path": str(output_dir / "metrics.json"),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Summary

Makes the repository demoable without private packet captures by adding a synthetic Radiotap/802.11 capture generator, a matching demo config, README instructions, and integration coverage for the happy path.

## Changes

- Adds `peekabo.capture.synthetic.write_synthetic_capture` for tiny fake Radiotap/Dot11 PCAP fixtures.
- Adds `examples/generate_synthetic_capture.py` and `configs/synthetic-demo.yaml`.
- Documents the synthetic-data quick path in README and examples docs.
- Makes `peekabo ingest` fail with a clear warning when no capture files are found, unless `--allow-empty` is passed.
- Imports Scapy Dot11 layers before opening PCAPs so Radiotap link types parse correctly in fresh CLI processes.
- Adds integration tests for synthetic ingest/features/label and the empty-input warning.

## Validation

- `make check PYTHON=.venv/bin/python` -> 18 passed
- `.venv/bin/python -m pytest -q` -> 18 passed
- `.venv/bin/python -m ruff check .` -> All checks passed
- `.venv/bin/python -m compileall -q src tests` -> passed
- Parsed all `.github/**/*.yml` files with PyYAML
- `python examples/generate_synthetic_capture.py && peekabo ingest/features/label --config configs/synthetic-demo.yaml` -> 5 records, 5 feature rows, 5 labeled rows

## Dependency housekeeping

- PR #3 was green and merged.
- PR #4 is green and mergeable, but GitHub rejected merge attempts from the available tokens because changing `.github/workflows/ci.yml` requires `workflow` scope.