### PR TITLE
[codex] Add end-to-end synthetic demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,33 @@ If `ingest` reports that no capture files were found, check that the configured 
 
 ## Try It With Synthetic Data
 
-The repository includes a generator for a tiny synthetic Radiotap/802.11 capture. It contains fake MAC addresses and fake frame metadata, so it is safe to use as a first-run demo.
+The repository includes a generator for a deterministic synthetic Radiotap/802.11 capture. It contains fake MAC addresses and fake frame metadata, so it is safe to use as a first-run demo. The synthetic traffic is intentionally learnable from allowed header-level features such as rate, signal, subtype, and frame size; it is not real-world performance evidence.
 
 ```bash
 python examples/generate_synthetic_capture.py
 peekabo ingest --config configs/synthetic-demo.yaml
 peekabo features --config configs/synthetic-demo.yaml
 peekabo label --config configs/synthetic-demo.yaml
+peekabo split --config configs/synthetic-demo.yaml
+peekabo train-online --config configs/synthetic-demo.yaml
+peekabo eval-holdout --config configs/synthetic-demo.yaml
+peekabo classify-file --config configs/synthetic-demo.yaml
+peekabo report --config configs/synthetic-demo.yaml
 ```
 
 The generated capture is written under `examples/captures/`, and pipeline outputs are written under `runs/`. Both locations are ignored by Git so real captures and generated datasets are not accidentally committed.
+
+After the full demo, `runs/synthetic-demo/` should include:
+
+- `records.parquet`: normalized Radiotap/Dot11 packet records
+- `features.parquet`: paper feature rows with MACs retained for labeling/reporting
+- `labeled.parquet`: binary `target` vs. `other` labels
+- `train.parquet` and `test.parquet`: chronological holdout split
+- `model.pkl`: online model checkpoint
+- `metrics.json`: holdout evaluation metrics
+- `predictions.parquet`: per-frame predictions
+- `rolling.parquet`: rolling target-presence summaries
+- `report.md`: Markdown experiment report
 
 ## Faithful Feature Policy
 

--- a/configs/synthetic-demo.yaml
+++ b/configs/synthetic-demo.yaml
@@ -37,6 +37,8 @@ model:
   checkpoint_path: runs/synthetic-demo/model.pkl
   params:
     n_models: 5
+    base_model:
+      grace_period: 5
 
 data:
   normalized_path: runs/synthetic-demo/records.parquet
@@ -54,13 +56,13 @@ sampling:
   class_weight_column: sample_weight
 
 split:
-  train_fraction: 0.9
+  train_fraction: 0.75
   chronological: true
 
 windowing:
-  frame_count: 100
-  time_seconds: 30
+  frame_count: 20
+  time_seconds: 20
   min_frames: 5
-  present_ratio_threshold: 0.5
-  mean_probability_threshold: 0.5
+  present_ratio_threshold: 0.3
+  mean_probability_threshold: 0.3
   max_probability_threshold: 0.8

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,19 @@
 # Examples
 
-Generate a tiny synthetic Radiotap/802.11 capture:
+Generate a deterministic synthetic Radiotap/802.11 capture and run the full demo pipeline:
 
 ```bash
 python examples/generate_synthetic_capture.py
 peekabo ingest --config configs/synthetic-demo.yaml
 peekabo features --config configs/synthetic-demo.yaml
 peekabo label --config configs/synthetic-demo.yaml
+peekabo split --config configs/synthetic-demo.yaml
+peekabo train-online --config configs/synthetic-demo.yaml
+peekabo eval-holdout --config configs/synthetic-demo.yaml
+peekabo classify-file --config configs/synthetic-demo.yaml
+peekabo report --config configs/synthetic-demo.yaml
 ```
 
-The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git.
+The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, and Markdown report under `runs/synthetic-demo/`, which is also ignored by Git.
 
 For real authorized monitor-mode captures, place PCAP or PCAPNG files under `examples/captures/`, then point a config at them. The repository intentionally does not include real wireless captures.

--- a/examples/generate_synthetic_capture.py
+++ b/examples/generate_synthetic_capture.py
@@ -20,8 +20,14 @@ def main() -> None:
         default=REPO_ROOT / "examples" / "captures" / "synthetic-demo.pcap",
         help="Output PCAP path.",
     )
+    parser.add_argument(
+        "--packet-count",
+        type=int,
+        default=120,
+        help="Number of synthetic packets to generate.",
+    )
     args = parser.parse_args()
-    output = write_synthetic_capture(args.output)
+    output = write_synthetic_capture(args.output, packet_count=args.packet_count)
     print(f"Wrote synthetic capture to {output}")
 
 

--- a/src/peekabo/capture/synthetic.py
+++ b/src/peekabo/capture/synthetic.py
@@ -11,8 +11,8 @@ UNKNOWN_MAC = "22:33:44:55:66:77"
 INTERNET_MAC = "ff:ff:ff:ff:ff:ff"
 
 
-def write_synthetic_capture(path: str | Path) -> Path:
-    """Write a tiny passive-safe Radiotap/Dot11 PCAP fixture."""
+def write_synthetic_capture(path: str | Path, *, packet_count: int = 120) -> Path:
+    """Write a deterministic passive-safe Radiotap/Dot11 PCAP fixture."""
     try:
         from scapy.layers.dot11 import Dot11, RadioTap  # type: ignore
         from scapy.packet import Raw  # type: ignore
@@ -22,15 +22,9 @@ def write_synthetic_capture(path: str | Path) -> Path:
 
     output = Path(path)
     output.parent.mkdir(parents=True, exist_ok=True)
-    packet_specs = [
-        (IPHONE_MAC, INTERNET_MAC, -41, 24, 12),
-        (LG_TV_MAC, INTERNET_MAC, -55, 18, 24),
-        (UNKNOWN_MAC, INTERNET_MAC, -67, 12, 36),
-        (IPHONE_MAC, INTERNET_MAC, -44, 36, 48),
-        (LG_TV_MAC, INTERNET_MAC, -53, 24, 60),
-    ]
     packets = []
-    for index, (source_mac, destination_mac, rssi, rate, payload_len) in enumerate(packet_specs):
+    for index in range(packet_count):
+        source_mac, destination_mac, rssi, rate, subtype, payload_len = _packet_spec(index)
         packet = (
             RadioTap(
                 present="Rate+Channel+dBm_AntSignal",
@@ -41,7 +35,7 @@ def write_synthetic_capture(path: str | Path) -> Path:
             )
             / Dot11(
                 type=2,
-                subtype=0,
+                subtype=subtype,
                 FCfield=0x41,
                 addr1=AP_MAC,
                 addr2=source_mac,
@@ -55,3 +49,32 @@ def write_synthetic_capture(path: str | Path) -> Path:
 
     wrpcap(str(output), packets)
     return output
+
+
+def _packet_spec(index: int) -> tuple[str, str, int, int, int, int]:
+    if index % 3 == 0:
+        return (
+            IPHONE_MAC,
+            INTERNET_MAC,
+            -38 - (index % 5),
+            54 if index % 2 else 48,
+            0,
+            72 + (index % 4) * 4,
+        )
+    if index % 3 == 1:
+        return (
+            LG_TV_MAC,
+            INTERNET_MAC,
+            -63 - (index % 4),
+            12 if index % 2 else 18,
+            4,
+            24 + (index % 3) * 3,
+        )
+    return (
+        UNKNOWN_MAC,
+        INTERNET_MAC,
+        -72 - (index % 6),
+        6 if index % 2 else 9,
+        8,
+        36 + (index % 5) * 2,
+    )

--- a/src/peekabo/cli.py
+++ b/src/peekabo/cli.py
@@ -281,7 +281,7 @@ def classify_file(
     pred_path = predictions_output or cfg.data.predictions_path
     roll_path = rolling_output or cfg.data.rolling_path
     write_rows(pred_path, predictions)
-    target = target_class or cfg.labeling.target_id or cfg.labeling.positive_label
+    target = target_class or _default_rolling_target_class(cfg)
     rolling = rolling_aggregates(predictions, target_class=target, config=cfg.windowing)
     write_rows(roll_path, rolling)
     typer.echo(f"Wrote {len(predictions)} predictions and {len(rolling)} rolling rows")
@@ -335,6 +335,12 @@ def _target_registry(cfg: AppConfig) -> TargetRegistry:
 
 def _write_run_config(cfg: AppConfig) -> None:
     write_run_config(cfg, cfg.output_dir)
+
+
+def _default_rolling_target_class(cfg: AppConfig) -> str:
+    if cfg.labeling.mode in {"binary_one_vs_rest", "per_target_binary"}:
+        return cfg.labeling.positive_label
+    return cfg.labeling.target_id or cfg.labeling.positive_label
 
 
 def _write_eval_outputs(

--- a/tests/test_demo_pipeline.py
+++ b/tests/test_demo_pipeline.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -10,7 +11,7 @@ from typer.testing import CliRunner
 from peekabo.capture.synthetic import IPHONE_MAC, write_synthetic_capture
 from peekabo.cli import app
 from peekabo.config import FeatureConfig
-from peekabo.data.readers import read_all_rows
+from peekabo.data.readers import read_all_rows, read_json
 from peekabo.features.extract import row_to_model_features
 
 pytest.importorskip("scapy")
@@ -35,15 +36,74 @@ def test_synthetic_capture_cli_pipeline(tmp_path: Path):
     records = read_all_rows(output_dir / "records.csv")
     features = read_all_rows(output_dir / "features.csv")
     labels = read_all_rows(output_dir / "labeled.csv")
-    assert len(records) == 5
-    assert len(features) == 5
-    assert len(labels) == 5
+    assert len(records) == 120
+    assert len(features) == 120
+    assert len(labels) == 120
     assert {row["label"] for row in labels} == {"target", "other"}
     assert any(row["source_mac"] == IPHONE_MAC for row in features)
 
     model_features = row_to_model_features(features[0], FeatureConfig())
     assert "source_mac" not in model_features
     assert "destination_mac" not in model_features
+
+
+def test_synthetic_capture_full_cli_demo_pipeline(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_demo_config(config_path, targets_path, capture_path, output_dir, suffix=".parquet")
+
+    runner = CliRunner()
+    for command in [
+        "ingest",
+        "features",
+        "label",
+        "split",
+        "train-online",
+        "eval-holdout",
+        "classify-file",
+        "report",
+    ]:
+        result = runner.invoke(app, [command, "--config", str(config_path)])
+        assert result.exit_code == 0, result.output
+
+    records = read_all_rows(output_dir / "records.parquet")
+    features = read_all_rows(output_dir / "features.parquet")
+    labels = read_all_rows(output_dir / "labeled.parquet")
+    train_rows = read_all_rows(output_dir / "train.parquet")
+    test_rows = read_all_rows(output_dir / "test.parquet")
+    predictions = read_all_rows(output_dir / "predictions.parquet")
+    rolling = read_all_rows(output_dir / "rolling.parquet")
+    metrics = read_json(output_dir / "metrics.json")
+
+    assert len(records) == 120
+    assert len(features) == 120
+    assert len(labels) == 120
+    assert train_rows
+    assert test_rows
+    assert predictions
+    assert rolling
+    assert (output_dir / "model.pkl").exists()
+    assert (output_dir / "report.md").exists()
+
+    assert {row["label"] for row in train_rows} == {"target", "other"}
+    assert {row["label"] for row in test_rows} == {"target", "other"}
+    for key in ["accuracy", "precision", "recall", "f1", "mcc", "roc_auc", "pr_auc"]:
+        assert key in metrics
+
+    feature_payload = json.loads(predictions[0]["features_json"])
+    assert "source_mac" not in feature_payload
+    assert "destination_mac" not in feature_payload
+    assert any(row["source_mac"] == IPHONE_MAC for row in predictions)
+    assert any(row["destination_mac"] for row in predictions)
+
+    assert {row["state"] for row in rolling} <= {"present", "absent", "uncertain"}
+    assert any(row["target_id"] == "target" for row in rolling)
+    assert any(row["state"] == "present" for row in rolling)
+    report_text = (output_dir / "report.md").read_text(encoding="utf-8")
+    assert "peekabo Experiment Report" in report_text
 
 
 def test_synthetic_capture_ingest_works_in_fresh_process(tmp_path: Path):
@@ -67,7 +127,7 @@ def test_synthetic_capture_ingest_works_in_fresh_process(tmp_path: Path):
 
     assert result.returncode == 0, result.stderr + result.stdout
     records = read_all_rows(output_dir / "records.csv")
-    assert len(records) == 5
+    assert len(records) == 120
     assert all(row["parse_ok"] for row in records)
 
 
@@ -97,6 +157,8 @@ def _write_demo_config(
     targets_path: Path,
     capture_path: Path,
     output_dir: Path,
+    *,
+    suffix: str = ".csv",
 ) -> None:
     targets_path.write_text(
         yaml.safe_dump(
@@ -133,14 +195,28 @@ def _write_demo_config(
                     "negative_label": "other",
                 },
                 "data": {
-                    "normalized_path": str(output_dir / "records.csv"),
-                    "features_path": str(output_dir / "features.csv"),
-                    "labeled_path": str(output_dir / "labeled.csv"),
-                    "train_path": str(output_dir / "train.csv"),
-                    "test_path": str(output_dir / "test.csv"),
-                    "predictions_path": str(output_dir / "predictions.csv"),
-                    "rolling_path": str(output_dir / "rolling.csv"),
+                    "normalized_path": str(output_dir / f"records{suffix}"),
+                    "features_path": str(output_dir / f"features{suffix}"),
+                    "labeled_path": str(output_dir / f"labeled{suffix}"),
+                    "train_path": str(output_dir / f"train{suffix}"),
+                    "test_path": str(output_dir / f"test{suffix}"),
+                    "predictions_path": str(output_dir / f"predictions{suffix}"),
+                    "rolling_path": str(output_dir / f"rolling{suffix}"),
                     "metrics_path": str(output_dir / "metrics.json"),
+                },
+                "model": {
+                    "model_id": "leveraging_bag",
+                    "checkpoint_path": str(output_dir / "model.pkl"),
+                    "params": {"n_models": 5, "base_model": {"grace_period": 5}},
+                },
+                "split": {"train_fraction": 0.75, "chronological": True},
+                "windowing": {
+                    "frame_count": 20,
+                    "time_seconds": 20,
+                    "min_frames": 5,
+                    "present_ratio_threshold": 0.3,
+                    "mean_probability_threshold": 0.3,
+                    "max_probability_threshold": 0.8,
                 },
             }
         ),


### PR DESCRIPTION
## Summary

- expands the synthetic Radiotap/802.11 generator into a deterministic 120-frame fixture with learnable metadata patterns
- extends the synthetic demo docs through split, train, holdout evaluation, classify, rolling aggregation, and report generation
- fixes binary classify-file rolling aggregation to default to the positive label instead of the target registry id
- adds a full CLI integration test for the Parquet demo artifacts, metrics, predictions, rolling output, and MAC leakage guardrail

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- documented synthetic demo command sequence produced 120 records, 120 feature rows, 120 labeled rows, 90 train rows, 30 test rows, model checkpoint, metrics, 120 predictions, 12 rolling rows, and report.md
