### PR TITLE
[codex] Add capture preflight diagnostics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 -
 
+Closes #
+
 ## Validation
 
 - [ ] `make check`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ make build PYTHON=.venv/bin/python
 
 Before opening a PR:
 
+- Open or reference a scoped GitHub Issue for non-trivial feature and bug work.
+- Link the PR with `Closes #<issue-number>` when the PR fully resolves the Issue.
 - Keep changes scoped and avoid unrelated refactors.
 - Do not commit packet captures, generated run outputs, credentials, or local virtual environments.
 - Include tests for behavior changes.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ python -m pip install -e ".[dev]"
 ## Quick Start
 
 ```bash
+peekaboo inspect --config configs/example.yaml
 peekaboo ingest --config configs/example.yaml
 peekaboo features --config configs/example.yaml
 peekaboo label --config configs/example.yaml
@@ -24,7 +25,7 @@ peekaboo report --config configs/example.yaml
 
 All commands accept a YAML config and targeted path/model overrides. Internal datasets are Parquet by default; CSV export is supported for interoperability.
 
-If `ingest` reports that no capture files were found, check that the configured `input.paths` exist and contain `.pcap`, `.pcapng`, or `.cap` files.
+Run `inspect` before `ingest` on new captures. It checks whether the PCAP inputs contain usable Radiotap and 802.11 metadata, writes `inspect.json` and `inspect.md`, and warns about common first-run problems. If `inspect` or `ingest` reports that no capture files were found, check that the configured `input.paths` exist and contain `.pcap`, `.pcapng`, or `.cap` files.
 
 ## Try It With Synthetic Data
 
@@ -32,6 +33,7 @@ The repository includes a generator for a deterministic synthetic Radiotap/802.1
 
 ```bash
 python examples/generate_synthetic_capture.py
+peekaboo inspect --config configs/synthetic-demo.yaml
 peekaboo ingest --config configs/synthetic-demo.yaml
 peekaboo features --config configs/synthetic-demo.yaml
 peekaboo label --config configs/synthetic-demo.yaml
@@ -46,6 +48,7 @@ The generated capture is written under `examples/captures/`, and pipeline output
 
 After the full demo, `runs/synthetic-demo/` should include:
 
+- `inspect.json` and `inspect.md`: capture preflight diagnostics
 - `records.parquet`: normalized Radiotap/Dot11 packet records
 - `features.parquet`: paper feature rows with MACs retained for labeling/reporting
 - `labeled.parquet`: binary `target` vs. `other` labels
@@ -84,6 +87,7 @@ The abstraction leaves room for a later MOA adapter if strict parity is required
 
 ```bash
 peekaboo ingest
+peekaboo inspect
 peekaboo features
 peekaboo label
 peekaboo sample
@@ -103,6 +107,7 @@ peekaboo report
 
 Typical runs create:
 
+- capture inspection summaries
 - normalized packet records
 - feature datasets
 - labeled datasets

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ Generate a deterministic synthetic Radiotap/802.11 capture and run the full demo
 
 ```bash
 python examples/generate_synthetic_capture.py
+peekaboo inspect --config configs/synthetic-demo.yaml
 peekaboo ingest --config configs/synthetic-demo.yaml
 peekaboo features --config configs/synthetic-demo.yaml
 peekaboo label --config configs/synthetic-demo.yaml

--- a/src/peekaboo/capture/inspect.py
+++ b/src/peekaboo/capture/inspect.py
@@ -1,0 +1,211 @@
+"""Capture preflight diagnostics."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from peekaboo.capture.sources import expand_input_paths, iter_packet_records
+from peekaboo.labeling.targets import TargetRegistry
+from peekaboo.parsing.dot11 import frame_family
+from peekaboo.parsing.records import PacketRecord
+
+RADIOTAP_FIELDS = ("data_rate", "channel_frequency", "rssi_or_ssi")
+FRAME_FAMILIES = ("management", "control", "data", "extension", "unknown")
+
+
+def inspect_capture_paths(
+    paths: Iterable[str | Path],
+    *,
+    registry: TargetRegistry | None = None,
+    max_packets: int | None = None,
+) -> dict[str, Any]:
+    """Inspect PCAP inputs without writing normalized packet datasets."""
+    capture_paths = expand_input_paths(paths)
+    return summarize_packet_records(
+        iter_packet_records(capture_paths),
+        capture_paths=capture_paths,
+        registry=registry,
+        max_packets=max_packets,
+    )
+
+
+def summarize_packet_records(
+    records: Iterable[PacketRecord | dict[str, Any]],
+    *,
+    capture_paths: Iterable[str | Path],
+    registry: TargetRegistry | None = None,
+    max_packets: int | None = None,
+) -> dict[str, Any]:
+    capture_files = [str(path) for path in capture_paths]
+    packets_scanned = 0
+    parse_successes = 0
+    parse_failures = 0
+    protected_frame_count = 0
+    field_present = Counter()
+    frame_counts = Counter({family: 0 for family in FRAME_FAMILIES})
+    channel_frequencies: set[int] = set()
+    source_macs: set[str] = set()
+    destination_macs: set[str] = set()
+    target_matches = Counter()
+
+    for record in records:
+        if max_packets is not None and packets_scanned >= max_packets:
+            break
+        row = record.to_dict() if isinstance(record, PacketRecord) else dict(record)
+        packets_scanned += 1
+
+        if row.get("parse_ok", True):
+            parse_successes += 1
+        else:
+            parse_failures += 1
+
+        family = frame_family(row.get("frame_type")) or "unknown"
+        frame_counts[family] += 1
+
+        if row.get("protected"):
+            protected_frame_count += 1
+        if row.get("data_rate") is not None:
+            field_present["data_rate"] += 1
+        if row.get("channel_frequency") is not None:
+            field_present["channel_frequency"] += 1
+            channel_frequencies.add(int(row["channel_frequency"]))
+        if row.get("rssi") is not None or row.get("ssi") is not None:
+            field_present["rssi_or_ssi"] += 1
+
+        source_mac = row.get("source_mac")
+        destination_mac = row.get("destination_mac")
+        if source_mac:
+            source_macs.add(str(source_mac))
+        if destination_mac:
+            destination_macs.add(str(destination_mac))
+        if registry is not None:
+            target_id = registry.target_id_for_mac(source_mac)
+            if target_id is not None:
+                target_matches[target_id] += 1
+
+    dot11_frame_count = parse_successes
+    parse_failure_rate = parse_failures / packets_scanned if packets_scanned else 0.0
+    radiotap_coverage = {
+        field: _coverage(field_present[field], packets_scanned) for field in RADIOTAP_FIELDS
+    }
+    summary: dict[str, Any] = {
+        "capture_file_count": len(capture_files),
+        "capture_files": capture_files,
+        "packets_scanned": packets_scanned,
+        "parse_successes": parse_successes,
+        "parse_failures": parse_failures,
+        "parse_failure_rate": parse_failure_rate,
+        "dot11_frame_count": dot11_frame_count,
+        "frame_family_counts": dict(frame_counts),
+        "protected_frame_count": protected_frame_count,
+        "channel_frequencies": sorted(channel_frequencies),
+        "radiotap_coverage": radiotap_coverage,
+        "source_mac_count": len(source_macs),
+        "destination_mac_count": len(destination_macs),
+        "target_match_total": sum(target_matches.values()),
+        "target_match_counts": dict(sorted(target_matches.items())),
+        "warnings": [],
+    }
+    summary["warnings"] = inspection_warnings(summary, registry=registry)
+    return summary
+
+
+def inspection_warnings(
+    summary: dict[str, Any],
+    *,
+    registry: TargetRegistry | None = None,
+) -> list[str]:
+    warnings: list[str] = []
+    packets_scanned = int(summary.get("packets_scanned") or 0)
+    dot11_frame_count = int(summary.get("dot11_frame_count") or 0)
+
+    if int(summary.get("capture_file_count") or 0) == 0:
+        warnings.append("No capture files were found.")
+    if packets_scanned and dot11_frame_count == 0:
+        warnings.append("No 802.11 Dot11 frames were parsed from the scanned packets.")
+    if float(summary.get("parse_failure_rate") or 0.0) >= 0.2:
+        warnings.append("At least 20% of scanned packets failed 802.11 parsing.")
+    if packets_scanned and _coverage_fraction(summary, "data_rate") == 0.0:
+        warnings.append("No Radiotap data-rate values were observed.")
+    if packets_scanned and _coverage_fraction(summary, "rssi_or_ssi") == 0.0:
+        warnings.append("No Radiotap RSSI/SSI signal values were observed.")
+    if dot11_frame_count and int(summary.get("protected_frame_count") or 0) == 0:
+        warnings.append(
+            "No protected 802.11 frames were observed; encrypted-network runs usually need them."
+        )
+    if (
+        registry is not None
+        and dot11_frame_count
+        and registry.enabled_target_ids()
+        and int(summary.get("target_match_total") or 0) == 0
+    ):
+        warnings.append("No source MACs matched enabled targets in the configured registry.")
+    return warnings
+
+
+def write_inspection_markdown(path: str | Path, summary: dict[str, Any]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# peekaboo Capture Inspection",
+        "",
+        "## Summary",
+        "",
+        f"- Capture files: `{summary.get('capture_file_count', 0)}`",
+        f"- Packets scanned: `{summary.get('packets_scanned', 0)}`",
+        f"- Dot11 frames: `{summary.get('dot11_frame_count', 0)}`",
+        f"- Parse successes: `{summary.get('parse_successes', 0)}`",
+        f"- Parse failures: `{summary.get('parse_failures', 0)}`",
+        f"- Protected frames: `{summary.get('protected_frame_count', 0)}`",
+        f"- Source MACs observed: `{summary.get('source_mac_count', 0)}`",
+        f"- Destination MACs observed: `{summary.get('destination_mac_count', 0)}`",
+        f"- Target matches: `{summary.get('target_match_total', 0)}`",
+        "",
+        "## Radiotap Coverage",
+        "",
+        "| Field | Present | Missing | Coverage |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for field, values in (summary.get("radiotap_coverage") or {}).items():
+        lines.append(
+            f"| `{field}` | {values.get('present', 0)} | {values.get('missing', 0)} | "
+            f"{values.get('coverage', 0.0):.1%} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Frame Families",
+            "",
+            "| Family | Count |",
+            "| --- | ---: |",
+        ]
+    )
+    for family, count in (summary.get("frame_family_counts") or {}).items():
+        lines.append(f"| `{family}` | {count} |")
+
+    lines.extend(["", "## Warnings", ""])
+    warnings = summary.get("warnings") or []
+    if warnings:
+        lines.extend(f"- {warning}" for warning in warnings)
+    else:
+        lines.append("- None")
+
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _coverage(present: int, total: int) -> dict[str, float | int]:
+    missing = max(total - present, 0)
+    return {
+        "present": present,
+        "missing": missing,
+        "coverage": present / total if total else 0.0,
+    }
+
+
+def _coverage_fraction(summary: dict[str, Any], field: str) -> float:
+    coverage = (summary.get("radiotap_coverage") or {}).get(field) or {}
+    return float(coverage.get("coverage") or 0.0)

--- a/src/peekaboo/cli.py
+++ b/src/peekaboo/cli.py
@@ -7,6 +7,7 @@ from typing import Annotated
 
 import typer
 
+from peekaboo.capture.inspect import inspect_capture_paths, write_inspection_markdown
 from peekaboo.capture.live import iter_live_records
 from peekaboo.capture.sources import expand_input_paths, iter_packet_records
 from peekaboo.config import AppConfig, load_config, write_run_config
@@ -37,6 +38,46 @@ app = typer.Typer(no_args_is_help=True, help="Passive 802.11 device identificati
 ConfigOption = Annotated[
     Path, typer.Option("--config", "-c", exists=True, help="YAML config path.")
 ]
+
+
+@app.command()
+def inspect(
+    config: ConfigOption,
+    input_path: Annotated[list[Path] | None, typer.Option("--input", "-i")] = None,
+    output_json: Annotated[Path | None, typer.Option("--output-json")] = None,
+    output_markdown: Annotated[Path | None, typer.Option("--output-markdown")] = None,
+    max_packets: Annotated[int | None, typer.Option("--max-packets")] = None,
+) -> None:
+    cfg = load_config(config)
+    paths = input_path or cfg.input.paths
+    capture_paths = expand_input_paths(paths)
+    if not capture_paths:
+        path_list = ", ".join(str(path) for path in paths) or "<none>"
+        typer.secho(
+            "No capture files found for input path(s): "
+            f"{path_list}. Expected .pcap, .pcapng, or .cap files.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    if max_packets is not None and max_packets < 1:
+        raise typer.BadParameter("--max-packets must be greater than 0")
+
+    registry = None
+    if cfg.target_registry_path is not None:
+        registry = TargetRegistry.from_file(cfg.target_registry_path)
+    summary = inspect_capture_paths(capture_paths, registry=registry, max_packets=max_packets)
+    json_path = output_json or cfg.output_dir / "inspect.json"
+    markdown_path = output_markdown or cfg.output_dir / "inspect.md"
+    write_json(json_path, summary)
+    write_inspection_markdown(markdown_path, summary)
+    typer.echo(
+        f"Inspected {summary['packets_scanned']} packets from "
+        f"{summary['capture_file_count']} capture file(s)"
+    )
+    for warning in summary["warnings"]:
+        typer.secho(f"Warning: {warning}", err=True)
+    typer.echo(f"Wrote inspection JSON to {json_path}")
+    typer.echo(f"Wrote inspection Markdown to {markdown_path}")
 
 
 @app.command()

--- a/tests/test_capture_inspect.py
+++ b/tests/test_capture_inspect.py
@@ -1,0 +1,94 @@
+from peekaboo.capture.inspect import summarize_packet_records
+from peekaboo.labeling.targets import TargetRegistry
+
+
+def test_inspection_summarizes_successful_records_and_target_matches():
+    registry = TargetRegistry.from_dict(
+        {
+            "targets": [
+                {
+                    "target_id": "phone",
+                    "label": "phone",
+                    "mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                }
+            ]
+        }
+    )
+    rows = [
+        {
+            "parse_ok": True,
+            "frame_type": 2,
+            "protected": True,
+            "data_rate": 54.0,
+            "channel_frequency": 2412,
+            "rssi": -42,
+            "source_mac": "aa:bb:cc:dd:ee:ff",
+            "destination_mac": "ff:ff:ff:ff:ff:ff",
+        },
+        {
+            "parse_ok": True,
+            "frame_type": 0,
+            "protected": False,
+            "data_rate": 24.0,
+            "channel_frequency": 2412,
+            "ssi": -60,
+            "source_mac": "11:22:33:44:55:66",
+            "destination_mac": "ff:ff:ff:ff:ff:ff",
+        },
+    ]
+
+    summary = summarize_packet_records(rows, capture_paths=["sample.pcap"], registry=registry)
+
+    assert summary["capture_file_count"] == 1
+    assert summary["packets_scanned"] == 2
+    assert summary["parse_successes"] == 2
+    assert summary["parse_failures"] == 0
+    assert summary["frame_family_counts"]["data"] == 1
+    assert summary["frame_family_counts"]["management"] == 1
+    assert summary["protected_frame_count"] == 1
+    assert summary["radiotap_coverage"]["data_rate"]["coverage"] == 1.0
+    assert summary["radiotap_coverage"]["rssi_or_ssi"]["coverage"] == 1.0
+    assert summary["channel_frequencies"] == [2412]
+    assert summary["source_mac_count"] == 2
+    assert summary["destination_mac_count"] == 1
+    assert summary["target_match_counts"] == {"phone": 1}
+    assert summary["warnings"] == []
+
+
+def test_inspection_warns_for_missing_fields_parse_failures_and_no_targets():
+    registry = TargetRegistry.from_dict(
+        {
+            "targets": [
+                {
+                    "target_id": "phone",
+                    "label": "phone",
+                    "mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                }
+            ]
+        }
+    )
+    rows = [
+        {"parse_ok": False, "parse_error": "packet has no 802.11 Dot11 layer"},
+        {"parse_ok": True, "frame_type": 2, "protected": False, "source_mac": "00:11:22:33:44:55"},
+    ]
+
+    summary = summarize_packet_records(rows, capture_paths=["sample.pcap"], registry=registry)
+
+    assert summary["packets_scanned"] == 2
+    assert summary["parse_failure_rate"] == 0.5
+    assert summary["radiotap_coverage"]["data_rate"]["coverage"] == 0.0
+    assert summary["target_match_total"] == 0
+    assert any("20%" in warning for warning in summary["warnings"])
+    assert any("data-rate" in warning for warning in summary["warnings"])
+    assert any("RSSI/SSI" in warning for warning in summary["warnings"])
+    assert any("No protected" in warning for warning in summary["warnings"])
+    assert any("No source MACs matched" in warning for warning in summary["warnings"])
+
+
+def test_inspection_honors_max_packets():
+    rows = [{"parse_ok": True, "frame_type": 2, "protected": True} for _ in range(5)]
+
+    summary = summarize_packet_records(rows, capture_paths=["sample.pcap"], max_packets=2)
+
+    assert summary["packets_scanned"] == 2
+    assert summary["dot11_frame_count"] == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,5 +6,6 @@ from peekaboo.cli import app
 def test_cli_help_smoke():
     result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
+    assert "inspect" in result.output
     assert "ingest" in result.output
     assert "eval-prequential" in result.output

--- a/tests/test_demo_pipeline.py
+++ b/tests/test_demo_pipeline.py
@@ -57,6 +57,7 @@ def test_synthetic_capture_full_cli_demo_pipeline(tmp_path: Path):
 
     runner = CliRunner()
     for command in [
+        "inspect",
         "ingest",
         "features",
         "label",
@@ -76,8 +77,11 @@ def test_synthetic_capture_full_cli_demo_pipeline(tmp_path: Path):
     test_rows = read_all_rows(output_dir / "test.parquet")
     predictions = read_all_rows(output_dir / "predictions.parquet")
     rolling = read_all_rows(output_dir / "rolling.parquet")
+    inspection = read_json(output_dir / "inspect.json")
     metrics = read_json(output_dir / "metrics.json")
 
+    assert inspection["packets_scanned"] == 120
+    assert inspection["target_match_total"] > 0
     assert len(records) == 120
     assert len(features) == 120
     assert len(labels) == 120
@@ -85,6 +89,7 @@ def test_synthetic_capture_full_cli_demo_pipeline(tmp_path: Path):
     assert test_rows
     assert predictions
     assert rolling
+    assert (output_dir / "inspect.md").exists()
     assert (output_dir / "model.pkl").exists()
     assert (output_dir / "report.md").exists()
 
@@ -131,6 +136,37 @@ def test_synthetic_capture_ingest_works_in_fresh_process(tmp_path: Path):
     assert all(row["parse_ok"] for row in records)
 
 
+def test_synthetic_capture_inspect_cli_outputs_diagnostics(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_demo_config(config_path, targets_path, capture_path, output_dir)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "inspect",
+            "--config",
+            str(config_path),
+            "--max-packets",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    summary = read_json(output_dir / "inspect.json")
+    assert summary["packets_scanned"] == 10
+    assert summary["capture_file_count"] == 1
+    assert summary["dot11_frame_count"] == 10
+    assert summary["radiotap_coverage"]["data_rate"]["present"] == 10
+    assert summary["radiotap_coverage"]["rssi_or_ssi"]["present"] == 10
+    assert summary["protected_frame_count"] == 10
+    assert summary["target_match_counts"]["iphone_5_user1"] > 0
+    assert (output_dir / "inspect.md").exists()
+
+
 def test_ingest_warns_and_fails_when_no_capture_files(tmp_path: Path):
     config_path = tmp_path / "empty.yaml"
     output_path = tmp_path / "records.csv"
@@ -150,6 +186,27 @@ def test_ingest_warns_and_fails_when_no_capture_files(tmp_path: Path):
     assert result.exit_code == 1
     assert "No capture files found" in result.output
     assert not output_path.exists()
+
+
+def test_inspect_warns_and_fails_when_no_capture_files(tmp_path: Path):
+    config_path = tmp_path / "empty.yaml"
+    output_dir = tmp_path / "runs"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input": {"paths": [str(tmp_path / "missing-captures")], "live_interface": None},
+                "output_dir": str(output_dir),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["inspect", "--config", str(config_path)])
+
+    assert result.exit_code == 1
+    assert "No capture files found" in result.output
+    assert not (output_dir / "inspect.json").exists()
+    assert not (output_dir / "inspect.md").exists()
 
 
 def _write_demo_config(


### PR DESCRIPTION
## Summary

- adds `peekaboo inspect` for passive PCAP preflight diagnostics before ingest/training
- writes JSON and Markdown inspection summaries with parse health, frame families, Radiotap coverage, protected-frame counts, MAC diagnostics, target matches, and warnings
- documents the new inspect-first flow and adds Issue-linking expectations to the PR template and contributor docs
- adds unit and CLI coverage for inspection summaries, max-packet limiting, missing inputs, and synthetic capture inspection

Closes #8

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- `python examples/generate_synthetic_capture.py`
- `peekaboo inspect --config configs/synthetic-demo.yaml`

## Safety

This remains passive-only and metadata-only. The inspect command reads configured PCAP/PCAPNG files and does not decrypt traffic, inspect payloads, inject frames, probe networks, configure interfaces, or perform live capture orchestration.
