### PR TITLE
[codex] Add live presence mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ peekaboo split --config configs/synthetic-demo.yaml
 peekaboo train-online --config configs/synthetic-demo.yaml
 peekaboo eval-holdout --config configs/synthetic-demo.yaml
 peekaboo classify-file --config configs/synthetic-demo.yaml
+peekaboo presence-replay --config configs/synthetic-demo.yaml
 peekaboo report --config configs/synthetic-demo.yaml
 ```
 
@@ -57,6 +58,7 @@ After the full demo, `runs/synthetic-demo/` should include:
 - `metrics.json`: holdout evaluation metrics
 - `predictions.parquet`: per-frame predictions
 - `rolling.parquet`: rolling target-presence summaries
+- `replay_predictions.jsonl` and `replay_presence.jsonl`: live-style replay output
 - `report.md`: Markdown experiment report
 
 ## Faithful Feature Policy
@@ -98,10 +100,14 @@ peekaboo eval-prequential
 peekaboo eval-holdout
 peekaboo classify-file
 peekaboo classify-live
+peekaboo presence-replay
+peekaboo presence-live
 peekaboo report
 ```
 
 `classify-live` is passive-only. It reads from a preconfigured monitor-mode interface and does not perform channel hopping or interface setup.
+
+`presence-live` is also passive-only. It loads a trained checkpoint, reads from an already configured monitor-mode interface, prints concise target-presence state changes, and writes streaming JSONL outputs. Use `presence-replay` on prepared feature rows to test the same runtime behavior without live wireless hardware.
 
 ## Output Artifacts
 
@@ -114,6 +120,7 @@ Typical runs create:
 - model checkpoints
 - per-frame predictions
 - rolling target-presence summaries
+- live/replay prediction and presence JSONL streams
 - JSON/CSV metrics
 - confusion matrices and plots
 - Markdown experiment reports

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,9 +12,10 @@ peekaboo split --config configs/synthetic-demo.yaml
 peekaboo train-online --config configs/synthetic-demo.yaml
 peekaboo eval-holdout --config configs/synthetic-demo.yaml
 peekaboo classify-file --config configs/synthetic-demo.yaml
+peekaboo presence-replay --config configs/synthetic-demo.yaml
 peekaboo report --config configs/synthetic-demo.yaml
 ```
 
-The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, and Markdown report under `runs/synthetic-demo/`, which is also ignored by Git.
+The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, and Markdown report under `runs/synthetic-demo/`, which is also ignored by Git.
 
 For real authorized monitor-mode captures, place PCAP or PCAPNG files under `examples/captures/`, then point a config at them. The repository intentionally does not include real wireless captures.

--- a/src/peekaboo/cli.py
+++ b/src/peekaboo/cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 
@@ -14,7 +14,7 @@ from peekaboo.config import AppConfig, load_config, write_run_config
 from peekaboo.data.readers import iter_rows
 from peekaboo.data.sampling import balance_file, random_sample_file
 from peekaboo.data.splits import split_file
-from peekaboo.data.writers import write_json, write_rows
+from peekaboo.data.writers import JsonlRowWriter, write_json, write_rows
 from peekaboo.evaluation.holdout import evaluate_holdout_rows, train_online_rows
 from peekaboo.evaluation.plots import (
     plot_binary_curves,
@@ -26,7 +26,12 @@ from peekaboo.evaluation.reports import write_markdown_report
 from peekaboo.features.extract import iter_feature_rows, model_feature_names
 from peekaboo.features.selection import rank_feature_file
 from peekaboo.inference.aggregate import rolling_aggregates
-from peekaboo.inference.classify import classify_rows
+from peekaboo.inference.classify import classify_row, classify_rows
+from peekaboo.inference.presence import (
+    PresenceStateTracker,
+    StreamingPresenceEngine,
+    format_presence_event,
+)
 from peekaboo.labeling.filters import passes_filters
 from peekaboo.labeling.labelers import iter_labeled_rows
 from peekaboo.labeling.targets import TargetRegistry
@@ -328,6 +333,70 @@ def classify_file(
     typer.echo(f"Wrote {len(predictions)} predictions and {len(rolling)} rolling rows")
 
 
+@app.command("presence-replay")
+def presence_replay(
+    config: ConfigOption,
+    input_path: Annotated[Path | None, typer.Option("--input", "-i")] = None,
+    checkpoint: Annotated[Path | None, typer.Option("--checkpoint")] = None,
+    predictions_output: Annotated[Path | None, typer.Option("--predictions-output")] = None,
+    presence_output: Annotated[Path | None, typer.Option("--presence-output")] = None,
+    target_class: Annotated[str | None, typer.Option("--target-class")] = None,
+    max_packets: Annotated[int | None, typer.Option("--max-packets")] = None,
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+) -> None:
+    cfg = load_config(config)
+    if max_packets is not None and max_packets < 1:
+        raise typer.BadParameter("--max-packets must be greater than 0")
+    model = load_checkpoint(checkpoint or cfg.model.checkpoint_path)
+    prediction_count, event_count = _run_presence_stream(
+        iter_rows(input_path or cfg.data.features_path),
+        model,
+        cfg,
+        target_class=target_class or _default_rolling_target_class(cfg),
+        predictions_output=predictions_output or cfg.output_dir / "replay_predictions.jsonl",
+        presence_output=presence_output or cfg.output_dir / "replay_presence.jsonl",
+        max_packets=max_packets,
+        quiet=quiet,
+    )
+    typer.echo(f"Wrote {prediction_count} replay predictions and {event_count} presence events")
+
+
+@app.command("presence-live")
+def presence_live(
+    config: ConfigOption,
+    checkpoint: Annotated[Path | None, typer.Option("--checkpoint")] = None,
+    interface: Annotated[str | None, typer.Option("--interface")] = None,
+    predictions_output: Annotated[Path | None, typer.Option("--predictions-output")] = None,
+    presence_output: Annotated[Path | None, typer.Option("--presence-output")] = None,
+    target_class: Annotated[str | None, typer.Option("--target-class")] = None,
+    max_packets: Annotated[int | None, typer.Option("--max-packets")] = None,
+    timeout_seconds: Annotated[float | None, typer.Option("--timeout-seconds")] = None,
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+) -> None:
+    cfg = load_config(config)
+    iface = interface or cfg.input.live_interface
+    if not iface:
+        raise typer.BadParameter("A monitor-mode interface is required")
+    if max_packets is not None and max_packets < 1:
+        raise typer.BadParameter("--max-packets must be greater than 0")
+    model = load_checkpoint(checkpoint or cfg.model.checkpoint_path)
+    feature_rows = iter_feature_rows(
+        iter_live_records(iface, timeout_seconds=timeout_seconds, max_packets=max_packets),
+        cfg.features,
+    )
+    prediction_count, event_count = _run_presence_stream(
+        feature_rows,
+        model,
+        cfg,
+        target_class=target_class or _default_rolling_target_class(cfg),
+        predictions_output=predictions_output or cfg.output_dir / "live_predictions.jsonl",
+        presence_output=presence_output or cfg.output_dir / "live_presence.jsonl",
+        max_packets=None,
+        quiet=quiet,
+    )
+    typer.echo(f"Wrote {prediction_count} live predictions and {event_count} presence events")
+
+
 @app.command("classify-live")
 def classify_live(
     config: ConfigOption,
@@ -382,6 +451,50 @@ def _default_rolling_target_class(cfg: AppConfig) -> str:
     if cfg.labeling.mode in {"binary_one_vs_rest", "per_target_binary"}:
         return cfg.labeling.positive_label
     return cfg.labeling.target_id or cfg.labeling.positive_label
+
+
+def _run_presence_stream(
+    rows: Any,
+    model: Any,
+    cfg: AppConfig,
+    *,
+    target_class: str,
+    predictions_output: Path,
+    presence_output: Path,
+    max_packets: int | None,
+    quiet: bool,
+) -> tuple[int, int]:
+    engine = StreamingPresenceEngine(target_class=target_class, config=cfg.windowing)
+    state_tracker = PresenceStateTracker()
+    prediction_count = 0
+    event_count = 0
+    with JsonlRowWriter(predictions_output, append=True) as predictions, JsonlRowWriter(
+        presence_output, append=True
+    ) as presence:
+        for row in rows:
+            if max_packets is not None and prediction_count >= max_packets:
+                break
+            prediction = classify_row(
+                row,
+                model,
+                cfg.features,
+                label_mode=cfg.labeling.mode,
+                packet_index=prediction_count,
+            )
+            predictions.write(prediction)
+            prediction_count += 1
+            for event in engine.process(prediction):
+                presence.write(event)
+                event_count += 1
+                if not quiet and state_tracker.is_change(event):
+                    typer.echo(format_presence_event(event))
+
+        for event in engine.flush():
+            presence.write(event)
+            event_count += 1
+            if not quiet and state_tracker.is_change(event):
+                typer.echo(format_presence_event(event))
+    return prediction_count, event_count
 
 
 def _write_eval_outputs(

--- a/src/peekaboo/data/writers.py
+++ b/src/peekaboo/data/writers.py
@@ -32,6 +32,27 @@ def write_json(path: str | Path, data: dict[str, Any]) -> None:
         json.dump(data, handle, indent=2, sort_keys=True)
 
 
+class JsonlRowWriter:
+    def __init__(self, path: str | Path, *, append: bool = False) -> None:
+        self.path = Path(path)
+        self.append = append
+        self._handle: Any = None
+
+    def __enter__(self) -> JsonlRowWriter:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.path.open("a" if self.append else "w", encoding="utf-8")
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        if self._handle is not None:
+            self._handle.close()
+
+    def write(self, row: dict[str, Any]) -> None:
+        if self._handle is None:
+            raise RuntimeError("JsonlRowWriter must be used as a context manager")
+        self._handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
 def _chunks(iterator: Iterator[dict[str, Any]], size: int) -> Iterator[list[dict[str, Any]]]:
     while True:
         chunk = list(islice(iterator, size))

--- a/src/peekaboo/inference/aggregate.py
+++ b/src/peekaboo/inference/aggregate.py
@@ -23,7 +23,13 @@ def rolling_frame_count(
         chunk = rows[start : start + config.frame_count]
         if chunk:
             output.append(
-                _summarize_window(chunk, start, start + len(chunk) - 1, target_class, config)
+                summarize_presence_window(
+                    chunk,
+                    start,
+                    start + len(chunk) - 1,
+                    target_class,
+                    config,
+                )
             )
     return output
 
@@ -45,7 +51,7 @@ def rolling_time(
     for bucket, rows in sorted(buckets.items()):
         start = bucket * config.time_seconds
         end = start + config.time_seconds
-        output.append(_summarize_window(rows, start, end, target_class, config))
+        output.append(summarize_presence_window(rows, start, end, target_class, config))
     return output
 
 
@@ -65,7 +71,7 @@ def rolling_aggregates(
     return frame_rows + time_rows
 
 
-def _summarize_window(
+def summarize_presence_window(
     rows: list[dict[str, Any]],
     window_start: float | int,
     window_end: float | int,

--- a/src/peekaboo/inference/classify.py
+++ b/src/peekaboo/inference/classify.py
@@ -23,27 +23,48 @@ def classify_rows(
 ) -> list[dict[str, Any]]:
     predictions: list[dict[str, Any]] = []
     for row in rows:
-        features = row_to_model_features(row, feature_config)
-        probabilities = model.predict_proba_one(features)
-        prediction = model.predict_one(features)
-        if prediction is None and probabilities:
-            prediction = max(probabilities, key=probabilities.get)
-        prediction = prediction or "__none__"
-        confidence = probabilities.get(prediction)
-        if confidence is None and probabilities:
-            confidence = max(probabilities.values())
         predictions.append(
-            PredictionRow(
-                timestamp=row.get("timestamp"),
-                packet_index=int(row.get("packet_index") or len(predictions)),
-                label_mode=str(row.get("label_mode") or label_mode),
-                predicted_class=str(prediction),
-                confidence=confidence,
-                ground_truth=None if row.get(label_column) is None else str(row.get(label_column)),
-                source_mac=row.get("source_mac"),
-                destination_mac=row.get("destination_mac"),
-                features_json=json.dumps(features, sort_keys=True),
-                probabilities_json=json.dumps(probabilities, sort_keys=True),
-            ).to_dict()
+            classify_row(
+                row,
+                model,
+                feature_config,
+                label_mode=label_mode,
+                label_column=label_column,
+                packet_index=len(predictions),
+            )
         )
     return predictions
+
+
+def classify_row(
+    row: dict[str, Any],
+    model: OnlineModel,
+    feature_config: FeatureConfig,
+    *,
+    label_mode: str = "unknown",
+    label_column: str = "label",
+    packet_index: int | None = None,
+) -> dict[str, Any]:
+    features = row_to_model_features(row, feature_config)
+    probabilities = model.predict_proba_one(features)
+    prediction = model.predict_one(features)
+    if prediction is None and probabilities:
+        prediction = max(probabilities, key=probabilities.get)
+    prediction = prediction or "__none__"
+    confidence = probabilities.get(prediction)
+    if confidence is None and probabilities:
+        confidence = max(probabilities.values())
+    return PredictionRow(
+        timestamp=row.get("timestamp"),
+        packet_index=int(
+            row.get("packet_index") if row.get("packet_index") is not None else packet_index or 0
+        ),
+        label_mode=str(row.get("label_mode") or label_mode),
+        predicted_class=str(prediction),
+        confidence=confidence,
+        ground_truth=None if row.get(label_column) is None else str(row.get(label_column)),
+        source_mac=row.get("source_mac"),
+        destination_mac=row.get("destination_mac"),
+        features_json=json.dumps(features, sort_keys=True),
+        probabilities_json=json.dumps(probabilities, sort_keys=True),
+    ).to_dict()

--- a/src/peekaboo/inference/presence.py
+++ b/src/peekaboo/inference/presence.py
@@ -1,0 +1,109 @@
+"""Streaming target-presence inference."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from peekaboo.config import WindowConfig
+from peekaboo.inference.aggregate import summarize_presence_window
+
+
+class StreamingPresenceEngine:
+    """Convert prediction rows into completed presence windows."""
+
+    def __init__(self, *, target_class: str, config: WindowConfig) -> None:
+        self.target_class = target_class
+        self.config = config
+        self._frame_rows: list[dict[str, Any]] = []
+        self._frame_start = 0
+        self._time_bucket: int | None = None
+        self._time_rows: list[dict[str, Any]] = []
+
+    def process(self, prediction: dict[str, Any]) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        self._frame_rows.append(prediction)
+        if len(self._frame_rows) >= self.config.frame_count:
+            events.append(self._flush_frame_window(final=False))
+
+        timestamp = prediction.get("timestamp")
+        if timestamp is not None:
+            bucket = int(float(timestamp) // self.config.time_seconds)
+            if self._time_bucket is None:
+                self._time_bucket = bucket
+            elif bucket != self._time_bucket:
+                events.append(self._flush_time_window(final=False))
+                self._time_bucket = bucket
+            self._time_rows.append(prediction)
+        return events
+
+    def flush(self) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        if self._frame_rows:
+            events.append(self._flush_frame_window(final=True))
+        if self._time_rows:
+            events.append(self._flush_time_window(final=True))
+        return events
+
+    def _flush_frame_window(self, *, final: bool) -> dict[str, Any]:
+        rows = self._frame_rows
+        window_start = self._frame_start
+        window_end = self._frame_start + len(rows) - 1
+        self._frame_start += len(rows)
+        self._frame_rows = []
+        event = summarize_presence_window(
+            rows,
+            window_start,
+            window_end,
+            self.target_class,
+            self.config,
+        )
+        event["window_type"] = "frame_count"
+        event["final_window"] = final
+        return event
+
+    def _flush_time_window(self, *, final: bool) -> dict[str, Any]:
+        rows = self._time_rows
+        bucket = self._time_bucket or 0
+        self._time_rows = []
+        event = summarize_presence_window(
+            rows,
+            bucket * self.config.time_seconds,
+            (bucket + 1) * self.config.time_seconds,
+            self.target_class,
+            self.config,
+        )
+        event["window_type"] = "time"
+        event["final_window"] = final
+        return event
+
+
+class PresenceStateTracker:
+    """Track state changes so terminal output stays concise."""
+
+    def __init__(self) -> None:
+        self._last_state: dict[tuple[str, str], str] = {}
+
+    def is_change(self, event: dict[str, Any]) -> bool:
+        key = (str(event.get("target_id")), str(event.get("window_type")))
+        state = str(event.get("state"))
+        previous = self._last_state.get(key)
+        self._last_state[key] = state
+        return previous != state
+
+
+def format_presence_event(event: dict[str, Any]) -> str:
+    return (
+        f"{event.get('window_type')} target={event.get('target_id')} "
+        f"state={event.get('state')} frames={event.get('frame_count')} "
+        f"mean={_fmt(event.get('mean_probability'))} "
+        f"max={_fmt(event.get('max_probability'))} "
+        f"positive_ratio={_fmt(event.get('positive_prediction_ratio'))}"
+    )
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,4 +8,6 @@ def test_cli_help_smoke():
     assert result.exit_code == 0
     assert "inspect" in result.output
     assert "ingest" in result.output
+    assert "presence-replay" in result.output
+    assert "presence-live" in result.output
     assert "eval-prequential" in result.output

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -1,0 +1,74 @@
+import json
+
+from peekaboo.config import WindowConfig
+from peekaboo.inference.presence import (
+    PresenceStateTracker,
+    StreamingPresenceEngine,
+    format_presence_event,
+)
+
+
+def prediction(timestamp: float, predicted_class: str = "target", probability: float = 0.9):
+    return {
+        "timestamp": timestamp,
+        "predicted_class": predicted_class,
+        "confidence": probability,
+        "probabilities_json": json.dumps({"target": probability, "other": 1 - probability}),
+    }
+
+
+def test_streaming_presence_emits_frame_windows_and_flushes_partial():
+    engine = StreamingPresenceEngine(
+        target_class="target",
+        config=WindowConfig(frame_count=3, min_frames=1),
+    )
+
+    assert engine.process(prediction(1)) == []
+    assert engine.process(prediction(2)) == []
+    events = engine.process(prediction(3))
+
+    assert len(events) == 1
+    assert events[0]["window_type"] == "frame_count"
+    assert events[0]["window_start"] == 0
+    assert events[0]["window_end"] == 2
+    assert events[0]["state"] == "present"
+    assert not events[0]["final_window"]
+
+    final_events = engine.flush()
+    assert len(final_events) == 1
+    assert final_events[0]["window_type"] == "time"
+    assert final_events[0]["final_window"]
+
+
+def test_streaming_presence_emits_time_windows_when_bucket_advances():
+    engine = StreamingPresenceEngine(
+        target_class="target",
+        config=WindowConfig(frame_count=100, time_seconds=10, min_frames=1),
+    )
+
+    assert engine.process(prediction(1)) == []
+    assert engine.process(prediction(8)) == []
+    events = engine.process(prediction(12))
+
+    assert len(events) == 1
+    assert events[0]["window_type"] == "time"
+    assert events[0]["window_start"] == 0
+    assert events[0]["window_end"] == 10
+    assert not events[0]["final_window"]
+
+    final_events = engine.flush()
+    assert len(final_events) == 2
+    assert {event["window_type"] for event in final_events} == {"frame_count", "time"}
+    assert all(event["final_window"] for event in final_events)
+
+
+def test_presence_state_tracker_reports_changes_without_duplicates():
+    tracker = PresenceStateTracker()
+    present_event = {"target_id": "target", "window_type": "frame_count", "state": "present"}
+    duplicate_event = {"target_id": "target", "window_type": "frame_count", "state": "present"}
+    absent_event = {"target_id": "target", "window_type": "frame_count", "state": "absent"}
+
+    assert tracker.is_change(present_event)
+    assert not tracker.is_change(duplicate_event)
+    assert tracker.is_change(absent_event)
+    assert "state=absent" in format_presence_event(absent_event)

--- a/tests/test_presence_cli.py
+++ b/tests/test_presence_cli.py
@@ -1,0 +1,162 @@
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from peekaboo.capture.synthetic import write_synthetic_capture
+from peekaboo.cli import app
+from peekaboo.data.readers import read_all_rows
+from peekaboo.models.base import OnlineModel
+from peekaboo.parsing.records import PacketRecord
+
+
+class AlwaysTargetEstimator:
+    def predict_proba_one(self, x):
+        return {"target": 1.0, "other": 0.0}
+
+    def predict_one(self, x):
+        return "target"
+
+    def learn_one(self, x, y):
+        return None
+
+
+def test_presence_replay_outputs_jsonl_and_honors_max_packets(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_config(config_path, capture_path, output_dir)
+
+    runner = CliRunner()
+    for command in ["ingest", "features", "label", "train-online"]:
+        result = runner.invoke(app, [command, "--config", str(config_path)])
+        assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        app,
+        [
+            "presence-replay",
+            "--config",
+            str(config_path),
+            "--max-packets",
+            "25",
+            "--quiet",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    predictions = read_all_rows(output_dir / "replay_predictions.jsonl")
+    presence = read_all_rows(output_dir / "replay_presence.jsonl")
+    assert len(predictions) == 25
+    assert presence
+    assert {row["state"] for row in presence} <= {"present", "absent", "uncertain"}
+    assert "source_mac" not in predictions[0]["features_json"]
+    assert "destination_mac" not in predictions[0]["features_json"]
+
+
+def test_presence_live_requires_interface(tmp_path: Path):
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, tmp_path / "missing.pcap", tmp_path / "runs")
+
+    result = CliRunner().invoke(app, ["presence-live", "--config", str(config_path)])
+
+    assert result.exit_code != 0
+    assert "monitor-mode interface" in result.output
+
+
+def test_presence_live_uses_passive_live_records_without_hardware(tmp_path: Path, monkeypatch):
+    output_dir = tmp_path / "runs"
+    config_path = tmp_path / "config.yaml"
+    checkpoint_path = output_dir / "model.pkl"
+    _write_config(config_path, tmp_path / "missing.pcap", output_dir)
+    OnlineModel("fake", AlwaysTargetEstimator(), [], {}).save(checkpoint_path)
+
+    def fake_live_records(interface, *, timeout_seconds=None, max_packets=None):
+        del interface, timeout_seconds
+        for index in range(max_packets or 5):
+            yield PacketRecord(
+                timestamp=float(index),
+                source_file="live:test0",
+                packet_index=index,
+                data_rate=54.0,
+                rssi=-40,
+                frame_type=2,
+                frame_subtype=0,
+                source_mac="aa:bb:cc:dd:ee:ff",
+                destination_mac="ff:ff:ff:ff:ff:ff",
+                dot11_frame_len=128,
+            )
+
+    monkeypatch.setattr("peekaboo.cli.iter_live_records", fake_live_records)
+    result = CliRunner().invoke(
+        app,
+        [
+            "presence-live",
+            "--config",
+            str(config_path),
+            "--interface",
+            "test0",
+            "--max-packets",
+            "5",
+            "--quiet",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(read_all_rows(output_dir / "live_predictions.jsonl")) == 5
+    assert read_all_rows(output_dir / "live_presence.jsonl")
+
+
+def _write_config(config_path: Path, capture_path: Path, output_dir: Path) -> None:
+    targets_path = output_dir / "targets.yaml"
+    targets_path.parent.mkdir(parents=True, exist_ok=True)
+    targets_path.write_text(
+        yaml.safe_dump(
+            {
+                "targets": [
+                    {
+                        "target_id": "iphone_5_user1",
+                        "label": "phone",
+                        "mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                        "enabled": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input": {"paths": [str(capture_path)], "live_interface": None},
+                "target_registry_path": str(targets_path),
+                "output_dir": str(output_dir),
+                "random_seed": 42,
+                "model": {
+                    "model_id": "leveraging_bag",
+                    "checkpoint_path": str(output_dir / "model.pkl"),
+                    "params": {"n_models": 5, "base_model": {"grace_period": 5}},
+                },
+                "data": {
+                    "normalized_path": str(output_dir / "records.parquet"),
+                    "features_path": str(output_dir / "features.parquet"),
+                    "labeled_path": str(output_dir / "labeled.parquet"),
+                    "train_path": str(output_dir / "train.parquet"),
+                    "test_path": str(output_dir / "test.parquet"),
+                    "predictions_path": str(output_dir / "predictions.parquet"),
+                    "rolling_path": str(output_dir / "rolling.parquet"),
+                    "metrics_path": str(output_dir / "metrics.json"),
+                },
+                "windowing": {
+                    "frame_count": 10,
+                    "time_seconds": 10,
+                    "min_frames": 2,
+                    "present_ratio_threshold": 0.3,
+                    "mean_probability_threshold": 0.3,
+                    "max_probability_threshold": 0.8,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Summary

- adds `peekaboo presence-replay` and `peekaboo presence-live`
- adds a streaming presence engine that converts per-frame predictions into frame-count and time-window presence events
- writes prediction and presence JSONL streams while preserving existing `classify-live`
- documents live/replay presence mode and adds unit/CLI coverage

Closes #10

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- `python examples/generate_synthetic_capture.py`
- `peekaboo inspect --config configs/synthetic-demo.yaml`
- `peekaboo ingest --config configs/synthetic-demo.yaml`
- `peekaboo features --config configs/synthetic-demo.yaml`
- `peekaboo label --config configs/synthetic-demo.yaml`
- `peekaboo split --config configs/synthetic-demo.yaml`
- `peekaboo train-online --config configs/synthetic-demo.yaml`
- `peekaboo presence-replay --config configs/synthetic-demo.yaml --quiet`

## Safety

This remains passive-only and metadata-only. Live mode reads from an already configured monitor-mode interface and does not decrypt traffic, inspect payloads, inject frames, probe networks, configure adapters, or channel hop.