### PR TITLE
[codex] Add one-command experiment runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,10 @@ python -m pip install -e ".[dev]"
 ## Quick Start
 
 ```bash
-peekaboo inspect --config configs/example.yaml
-peekaboo ingest --config configs/example.yaml
-peekaboo features --config configs/example.yaml
-peekaboo label --config configs/example.yaml
-peekaboo eval-prequential --config configs/example.yaml
-peekaboo report --config configs/example.yaml
+peekaboo run --config configs/example.yaml
 ```
+
+`peekaboo run` executes the configured pipeline, writes `run_manifest.json` and `run_summary.md`, and records each stage as completed, skipped, or failed. Use `--dry-run` to print the planned stages, `--force` to overwrite existing stage outputs, or `--skip-existing` to reuse completed artifacts.
 
 All commands accept a YAML config and targeted path/model overrides. Internal datasets are Parquet by default; CSV export is supported for interoperability.
 
@@ -33,6 +30,14 @@ The repository includes a generator for a deterministic synthetic Radiotap/802.1
 
 ```bash
 python examples/generate_synthetic_capture.py
+peekaboo run --config configs/synthetic-demo.yaml
+```
+
+The generated capture is written under `examples/captures/`, and pipeline outputs are written under `runs/`. Both locations are ignored by Git so real captures and generated datasets are not accidentally committed.
+
+To run the synthetic demo one stage at a time instead, use:
+
+```bash
 peekaboo inspect --config configs/synthetic-demo.yaml
 peekaboo ingest --config configs/synthetic-demo.yaml
 peekaboo features --config configs/synthetic-demo.yaml
@@ -45,10 +50,9 @@ peekaboo presence-replay --config configs/synthetic-demo.yaml
 peekaboo report --config configs/synthetic-demo.yaml
 ```
 
-The generated capture is written under `examples/captures/`, and pipeline outputs are written under `runs/`. Both locations are ignored by Git so real captures and generated datasets are not accidentally committed.
-
 After the full demo, `runs/synthetic-demo/` should include:
 
+- `run_manifest.json` and `run_summary.md`: reproducible run provenance and stage summary
 - `inspect.json` and `inspect.md`: capture preflight diagnostics
 - `records.parquet`: normalized Radiotap/Dot11 packet records
 - `features.parquet`: paper feature rows with MACs retained for labeling/reporting
@@ -88,6 +92,7 @@ The abstraction leaves room for a later MOA adapter if strict parity is required
 ## CLI Commands
 
 ```bash
+peekaboo run
 peekaboo ingest
 peekaboo inspect
 peekaboo features
@@ -104,6 +109,13 @@ peekaboo presence-replay
 peekaboo presence-live
 peekaboo report
 ```
+
+Runner profiles:
+
+- `peekaboo run --profile full`: inspect, ingest, feature extraction, labeling, split, train, holdout evaluation, file classification, replay presence, report
+- `peekaboo run --profile prepare`: inspect through split
+- `peekaboo run --profile train-eval`: train, holdout evaluation, file classification, report
+- `peekaboo run --profile presence-replay`: train and replay presence output
 
 `classify-live` is passive-only. It reads from a preconfigured monitor-mode interface and does not perform channel hopping or interface setup.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,14 @@ Generate a deterministic synthetic Radiotap/802.11 capture and run the full demo
 
 ```bash
 python examples/generate_synthetic_capture.py
+peekaboo run --config configs/synthetic-demo.yaml
+```
+
+The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, `run_manifest.json`, `run_summary.md`, and Markdown report under `runs/synthetic-demo/`, which is also ignored by Git.
+
+To run the same workflow manually one command at a time:
+
+```bash
 peekaboo inspect --config configs/synthetic-demo.yaml
 peekaboo ingest --config configs/synthetic-demo.yaml
 peekaboo features --config configs/synthetic-demo.yaml
@@ -15,7 +23,5 @@ peekaboo classify-file --config configs/synthetic-demo.yaml
 peekaboo presence-replay --config configs/synthetic-demo.yaml
 peekaboo report --config configs/synthetic-demo.yaml
 ```
-
-The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, and Markdown report under `runs/synthetic-demo/`, which is also ignored by Git.
 
 For real authorized monitor-mode captures, place PCAP or PCAPNG files under `examples/captures/`, then point a config at them. The repository intentionally does not include real wireless captures.

--- a/src/peekaboo/cli.py
+++ b/src/peekaboo/cli.py
@@ -37,12 +37,52 @@ from peekaboo.labeling.labelers import iter_labeled_rows
 from peekaboo.labeling.targets import TargetRegistry
 from peekaboo.models.base import load_checkpoint
 from peekaboo.models.registry import create_model
+from peekaboo.runner import ExperimentRunError, run_experiment
 
 app = typer.Typer(no_args_is_help=True, help="Passive 802.11 device identification.")
 
 ConfigOption = Annotated[
     Path, typer.Option("--config", "-c", exists=True, help="YAML config path.")
 ]
+
+
+@app.command("run")
+def run_command(
+    config: ConfigOption,
+    profile: Annotated[str, typer.Option("--profile")] = "full",
+    from_stage: Annotated[str | None, typer.Option("--from-stage")] = None,
+    to_stage: Annotated[str | None, typer.Option("--to-stage")] = None,
+    force: Annotated[bool, typer.Option("--force")] = False,
+    skip_existing: Annotated[bool, typer.Option("--skip-existing")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+) -> None:
+    try:
+        manifest = run_experiment(
+            config,
+            profile=profile,
+            from_stage=from_stage,
+            to_stage=to_stage,
+            force=force,
+            skip_existing=skip_existing,
+            dry_run=dry_run,
+            quiet=quiet,
+            progress=None if dry_run else typer.echo,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except ExperimentRunError as exc:
+        typer.secho(str(exc), err=True)
+        raise typer.Exit(1) from exc
+
+    stages = " -> ".join(manifest["stage_order"])
+    if dry_run:
+        typer.echo(f"Dry run planned stages: {stages}")
+        return
+    typer.echo(
+        f"Run {manifest['status']} with {len(manifest['stages'])} stage(s). "
+        f"Wrote {manifest['artifacts']['run_manifest']}"
+    )
 
 
 @app.command()

--- a/src/peekaboo/runner.py
+++ b/src/peekaboo/runner.py
@@ -1,0 +1,593 @@
+"""Config-driven experiment runner."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from peekaboo import __version__
+from peekaboo.capture.inspect import inspect_capture_paths, write_inspection_markdown
+from peekaboo.capture.sources import expand_input_paths, iter_packet_records
+from peekaboo.config import AppConfig, load_config, write_run_config
+from peekaboo.data.readers import iter_rows, read_json
+from peekaboo.data.splits import split_file
+from peekaboo.data.writers import JsonlRowWriter, write_json, write_rows
+from peekaboo.evaluation.holdout import evaluate_holdout_rows, train_online_rows
+from peekaboo.evaluation.plots import (
+    plot_binary_curves,
+    plot_confusion_matrix,
+    write_confusion_matrix_csv,
+)
+from peekaboo.evaluation.reports import write_markdown_report
+from peekaboo.features.extract import iter_feature_rows, model_feature_names
+from peekaboo.inference.aggregate import rolling_aggregates
+from peekaboo.inference.classify import classify_row, classify_rows
+from peekaboo.inference.presence import StreamingPresenceEngine
+from peekaboo.labeling.filters import passes_filters
+from peekaboo.labeling.labelers import iter_labeled_rows
+from peekaboo.labeling.targets import TargetRegistry
+from peekaboo.models.base import load_checkpoint
+from peekaboo.models.registry import create_model
+
+StageName = str
+ProgressCallback = Callable[[str], None]
+
+STAGE_ORDER: tuple[StageName, ...] = (
+    "inspect",
+    "ingest",
+    "features",
+    "label",
+    "split",
+    "train",
+    "eval",
+    "classify",
+    "presence",
+    "report",
+)
+
+PROFILES: dict[str, tuple[StageName, ...]] = {
+    "full": STAGE_ORDER,
+    "prepare": ("inspect", "ingest", "features", "label", "split"),
+    "train-eval": ("train", "eval", "classify", "report"),
+    "presence-replay": ("train", "presence"),
+}
+
+
+class ExperimentRunError(RuntimeError):
+    """Raised when an experiment runner stage fails."""
+
+
+@dataclass(frozen=True)
+class RunOptions:
+    profile: str = "full"
+    from_stage: str | None = None
+    to_stage: str | None = None
+    force: bool = False
+    skip_existing: bool = False
+    dry_run: bool = False
+    quiet: bool = False
+
+
+def plan_stages(
+    *,
+    profile: str = "full",
+    from_stage: str | None = None,
+    to_stage: str | None = None,
+) -> list[StageName]:
+    if profile not in PROFILES:
+        raise ValueError(f"Unknown run profile {profile!r}; expected one of {sorted(PROFILES)}")
+    stages = list(PROFILES[profile])
+    if from_stage is not None:
+        _require_stage_in_profile(from_stage, stages, profile)
+        stages = stages[stages.index(from_stage) :]
+    if to_stage is not None:
+        _require_stage_in_profile(to_stage, stages, profile)
+        stages = stages[: stages.index(to_stage) + 1]
+    if not stages:
+        raise ValueError("No stages selected")
+    return stages
+
+
+def stage_outputs(config: AppConfig, stage: StageName) -> list[Path]:
+    output_dir = config.output_dir
+    paths: dict[StageName, list[Path]] = {
+        "inspect": [output_dir / "inspect.json", output_dir / "inspect.md"],
+        "ingest": [config.data.normalized_path],
+        "features": [config.data.features_path],
+        "label": [config.data.labeled_path],
+        "split": [config.data.train_path, config.data.test_path],
+        "train": [config.model.checkpoint_path],
+        "eval": [config.data.metrics_path],
+        "classify": [config.data.predictions_path, config.data.rolling_path],
+        "presence": [
+            output_dir / "replay_predictions.jsonl",
+            output_dir / "replay_presence.jsonl",
+        ],
+        "report": [output_dir / "report.md"],
+    }
+    return paths[stage]
+
+
+def stage_outputs_exist(config: AppConfig, stage: StageName) -> bool:
+    outputs = stage_outputs(config, stage)
+    return bool(outputs) and all(path.exists() for path in outputs)
+
+
+def run_experiment(
+    config_path: str | Path,
+    *,
+    profile: str = "full",
+    from_stage: str | None = None,
+    to_stage: str | None = None,
+    force: bool = False,
+    skip_existing: bool = False,
+    dry_run: bool = False,
+    quiet: bool = False,
+    progress: ProgressCallback | None = None,
+) -> dict[str, Any]:
+    if force and skip_existing:
+        raise ValueError("Use either --force or --skip-existing, not both")
+
+    config = load_config(config_path)
+    options = RunOptions(
+        profile=profile,
+        from_stage=from_stage,
+        to_stage=to_stage,
+        force=force,
+        skip_existing=skip_existing,
+        dry_run=dry_run,
+        quiet=quiet,
+    )
+    stages = plan_stages(profile=profile, from_stage=from_stage, to_stage=to_stage)
+    manifest = _new_manifest(config, Path(config_path), options, stages)
+
+    if dry_run:
+        manifest["status"] = "dry_run"
+        manifest["ended_at"] = _now()
+        if progress is not None:
+            progress("Planned stages: " + " -> ".join(stages))
+        return manifest
+
+    conflicts = _preexisting_outputs(config, stages)
+    if conflicts and not force and not skip_existing:
+        error = (
+            "Output files already exist; use --force to overwrite or --skip-existing "
+            f"to reuse them: {', '.join(str(path) for path in conflicts)}"
+        )
+        manifest["stages"].append(_stage_result("preflight", "failed", error=error))
+        manifest["status"] = "failed"
+        manifest["ended_at"] = _now()
+        _write_run_outputs(config, manifest)
+        raise ExperimentRunError(error)
+
+    for stage in stages:
+        if skip_existing and stage_outputs_exist(config, stage):
+            result = _stage_result(
+                stage,
+                "skipped",
+                outputs=stage_outputs(config, stage),
+                message="All required outputs already exist.",
+            )
+            manifest["stages"].append(result)
+            if progress is not None and not quiet:
+                progress(f"Skipped {stage}; outputs already exist")
+            continue
+
+        if force:
+            _remove_outputs(stage_outputs(config, stage))
+
+        if progress is not None and not quiet:
+            progress(f"Running {stage}")
+        result = _stage_result(stage, "running", outputs=stage_outputs(config, stage))
+        try:
+            counts = _run_stage(config, stage, quiet=quiet)
+        except Exception as exc:
+            result["status"] = "failed"
+            result["error"] = str(exc)
+            result["ended_at"] = _now()
+            manifest["stages"].append(result)
+            manifest["status"] = "failed"
+            manifest["ended_at"] = _now()
+            _write_run_outputs(config, manifest)
+            raise ExperimentRunError(f"Stage {stage} failed: {exc}") from exc
+
+        result["status"] = "completed"
+        result["row_counts"] = counts
+        result["ended_at"] = _now()
+        manifest["stages"].append(result)
+
+    manifest["status"] = "completed"
+    manifest["ended_at"] = _now()
+    _write_run_outputs(config, manifest)
+    return manifest
+
+
+def write_run_summary(path: str | Path, manifest: dict[str, Any]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# peekaboo Run Summary",
+        "",
+        f"- Status: `{manifest.get('status')}`",
+        f"- Config: `{manifest.get('config_path')}`",
+        f"- Profile: `{manifest.get('profile')}`",
+        f"- Random seed: `{manifest.get('random_seed')}`",
+        f"- Started: `{manifest.get('started_at')}`",
+        f"- Ended: `{manifest.get('ended_at')}`",
+        "",
+        "## Stages",
+        "",
+        "| Stage | Status | Counts |",
+        "| --- | --- | --- |",
+    ]
+    for stage in manifest.get("stages", []):
+        counts = stage.get("row_counts") or {}
+        count_text = ", ".join(f"{key}={value}" for key, value in counts.items()) or "-"
+        lines.append(f"| `{stage.get('name')}` | `{stage.get('status')}` | {count_text} |")
+
+    lines.extend(
+        [
+            "",
+            "## Key Artifacts",
+            "",
+        ]
+    )
+    for name, path_value in (manifest.get("artifacts") or {}).items():
+        lines.append(f"- `{name}`: `{path_value}`")
+
+    failures = [stage for stage in manifest.get("stages", []) if stage.get("status") == "failed"]
+    if failures:
+        lines.extend(["", "## Failures", ""])
+        for failure in failures:
+            lines.append(f"- `{failure.get('name')}`: {failure.get('error')}")
+
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_stage(config: AppConfig, stage: StageName, *, quiet: bool) -> dict[str, int]:
+    stage_handlers = {
+        "inspect": _run_inspect,
+        "ingest": _run_ingest,
+        "features": _run_features,
+        "label": _run_label,
+        "split": _run_split,
+        "train": _run_train,
+        "eval": _run_eval_holdout,
+        "classify": _run_classify_file,
+        "presence": _run_presence_replay,
+        "report": _run_report,
+    }
+    return stage_handlers[stage](config, quiet=quiet)
+
+
+def _run_inspect(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    capture_paths = _capture_paths_or_raise(config)
+    registry = _target_registry_optional(config)
+    summary = inspect_capture_paths(capture_paths, registry=registry)
+    write_json(config.output_dir / "inspect.json", summary)
+    write_inspection_markdown(config.output_dir / "inspect.md", summary)
+    return {
+        "capture_files": int(summary["capture_file_count"]),
+        "packets_scanned": int(summary["packets_scanned"]),
+        "dot11_frames": int(summary["dot11_frame_count"]),
+    }
+
+
+def _run_ingest(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    capture_paths = _capture_paths_or_raise(config)
+    write_run_config(config, config.output_dir)
+    count = write_rows(
+        config.data.normalized_path,
+        (record.to_dict() for record in iter_packet_records(capture_paths)),
+    )
+    return {"records": count}
+
+
+def _run_features(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    rows = (row for row in iter_rows(config.data.normalized_path) if row.get("parse_ok", True))
+    count = write_rows(config.data.features_path, iter_feature_rows(rows, config.features))
+    return {"features": count}
+
+
+def _run_label(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    registry = _target_registry(config)
+
+    def filtered_rows():
+        for row in iter_rows(config.data.features_path):
+            if passes_filters(row, config.filters, registry=registry):
+                yield row
+
+    count = write_rows(
+        config.data.labeled_path,
+        iter_labeled_rows(filtered_rows(), registry, config.labeling),
+    )
+    return {"labels": count}
+
+
+def _run_split(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    train_count, test_count = split_file(
+        config.data.labeled_path,
+        config.data.train_path,
+        config.data.test_path,
+        train_fraction=config.split.train_fraction,
+        chronological=config.split.chronological,
+        seed=config.random_seed,
+    )
+    return {"train": train_count, "test": test_count}
+
+
+def _run_train(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    model = create_model(
+        config.model.model_id,
+        feature_names=model_feature_names(config.features),
+        seed=config.random_seed,
+        params=config.model.params,
+    )
+    count = train_online_rows(
+        iter_rows(config.data.labeled_path),
+        model,
+        config.features,
+        weight_column=config.sampling.class_weight_column,
+    )
+    model.save(config.model.checkpoint_path)
+    return {"train_examples": count}
+
+
+def _run_eval_holdout(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    model = create_model(
+        config.model.model_id,
+        feature_names=model_feature_names(config.features),
+        seed=config.random_seed,
+        params=config.model.params,
+    )
+    metrics, predictions = evaluate_holdout_rows(
+        iter_rows(config.data.train_path),
+        iter_rows(config.data.test_path),
+        model,
+        config.features,
+        positive_label=config.labeling.positive_label,
+        weight_column=config.sampling.class_weight_column,
+    )
+    _write_eval_outputs(config, metrics, predictions)
+    return {
+        "train_examples": int(metrics.get("train_examples") or 0),
+        "eval_examples": int(metrics.get("n_examples") or 0),
+        "predictions": len(predictions),
+    }
+
+
+def _run_classify_file(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    model = load_checkpoint(config.model.checkpoint_path)
+    predictions = classify_rows(
+        iter_rows(config.data.features_path),
+        model,
+        config.features,
+        label_mode=config.labeling.mode,
+        positive_label=config.labeling.positive_label,
+    )
+    write_rows(config.data.predictions_path, predictions)
+    target = _default_rolling_target_class(config)
+    rolling = rolling_aggregates(predictions, target_class=target, config=config.windowing)
+    write_rows(config.data.rolling_path, rolling)
+    return {"predictions": len(predictions), "rolling": len(rolling)}
+
+
+def _run_presence_replay(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    model = load_checkpoint(config.model.checkpoint_path)
+    prediction_count, event_count = _write_presence_stream(
+        iter_rows(config.data.features_path),
+        model,
+        config,
+        target_class=_default_rolling_target_class(config),
+        predictions_output=config.output_dir / "replay_predictions.jsonl",
+        presence_output=config.output_dir / "replay_presence.jsonl",
+        quiet=quiet,
+    )
+    return {"predictions": prediction_count, "presence_events": event_count}
+
+
+def _run_report(config: AppConfig, *, quiet: bool) -> dict[str, int]:
+    del quiet
+    metrics = read_json(config.data.metrics_path)
+    write_markdown_report(config.output_dir / "report.md", config=config, metrics=metrics)
+    return {"reports": 1}
+
+
+def _write_presence_stream(
+    rows: Any,
+    model: Any,
+    config: AppConfig,
+    *,
+    target_class: str,
+    predictions_output: Path,
+    presence_output: Path,
+    quiet: bool,
+) -> tuple[int, int]:
+    del quiet
+    engine = StreamingPresenceEngine(target_class=target_class, config=config.windowing)
+    prediction_count = 0
+    event_count = 0
+    with JsonlRowWriter(predictions_output) as predictions, JsonlRowWriter(
+        presence_output
+    ) as presence:
+        for row in rows:
+            prediction = classify_row(
+                row,
+                model,
+                config.features,
+                label_mode=config.labeling.mode,
+                packet_index=prediction_count,
+            )
+            predictions.write(prediction)
+            prediction_count += 1
+            for event in engine.process(prediction):
+                presence.write(event)
+                event_count += 1
+
+        for event in engine.flush():
+            presence.write(event)
+            event_count += 1
+    return prediction_count, event_count
+
+
+def _write_eval_outputs(
+    config: AppConfig,
+    metrics: dict[str, Any],
+    predictions: list[dict[str, Any]],
+) -> None:
+    write_json(config.data.metrics_path, metrics)
+    write_rows(config.data.predictions_path, predictions)
+    write_confusion_matrix_csv(config.output_dir / "confusion_matrix.csv", metrics)
+    try:
+        plot_confusion_matrix(config.output_dir / "confusion_matrix.png", metrics)
+    except RuntimeError:
+        pass
+    try:
+        plot_binary_curves(
+            config.output_dir / "roc_curve.png",
+            config.output_dir / "pr_curve.png",
+            predictions,
+            positive_label=config.labeling.positive_label,
+        )
+    except RuntimeError:
+        pass
+    write_markdown_report(config.output_dir / "report.md", config=config, metrics=metrics)
+
+
+def _new_manifest(
+    config: AppConfig,
+    config_path: Path,
+    options: RunOptions,
+    stages: list[StageName],
+) -> dict[str, Any]:
+    return {
+        "status": "running",
+        "package_version": __version__,
+        "config_path": str(config_path),
+        "profile": options.profile,
+        "from_stage": options.from_stage,
+        "to_stage": options.to_stage,
+        "force": options.force,
+        "skip_existing": options.skip_existing,
+        "dry_run": options.dry_run,
+        "random_seed": config.random_seed,
+        "started_at": _now(),
+        "ended_at": None,
+        "stage_order": stages,
+        "stages": [],
+        "artifacts": _artifact_paths(config),
+    }
+
+
+def _stage_result(
+    name: str,
+    status: str,
+    *,
+    outputs: list[Path] | None = None,
+    row_counts: dict[str, int] | None = None,
+    message: str | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "name": name,
+        "status": status,
+        "started_at": _now(),
+        "ended_at": _now() if status in {"completed", "skipped", "failed"} else None,
+        "outputs": [str(path) for path in outputs or []],
+        "row_counts": row_counts or {},
+    }
+    if message is not None:
+        result["message"] = message
+    if error is not None:
+        result["error"] = error
+    return result
+
+
+def _write_run_outputs(config: AppConfig, manifest: dict[str, Any]) -> None:
+    write_json(config.output_dir / "run_manifest.json", manifest)
+    write_run_summary(config.output_dir / "run_summary.md", manifest)
+
+
+def _artifact_paths(config: AppConfig) -> dict[str, str]:
+    return {
+        "run_manifest": str(config.output_dir / "run_manifest.json"),
+        "run_summary": str(config.output_dir / "run_summary.md"),
+        "inspection_json": str(config.output_dir / "inspect.json"),
+        "inspection_markdown": str(config.output_dir / "inspect.md"),
+        "records": str(config.data.normalized_path),
+        "features": str(config.data.features_path),
+        "labels": str(config.data.labeled_path),
+        "train": str(config.data.train_path),
+        "test": str(config.data.test_path),
+        "model": str(config.model.checkpoint_path),
+        "metrics": str(config.data.metrics_path),
+        "predictions": str(config.data.predictions_path),
+        "rolling": str(config.data.rolling_path),
+        "replay_predictions": str(config.output_dir / "replay_predictions.jsonl"),
+        "replay_presence": str(config.output_dir / "replay_presence.jsonl"),
+        "report": str(config.output_dir / "report.md"),
+    }
+
+
+def _preexisting_outputs(config: AppConfig, stages: list[StageName]) -> list[Path]:
+    paths: list[Path] = []
+    for stage in stages:
+        for path in stage_outputs(config, stage):
+            if path.exists() and path not in paths:
+                paths.append(path)
+    return paths
+
+
+def _remove_outputs(paths: list[Path]) -> None:
+    for path in paths:
+        if path.exists() and path.is_file():
+            path.unlink()
+
+
+def _capture_paths_or_raise(config: AppConfig) -> list[Path]:
+    capture_paths = expand_input_paths(config.input.paths)
+    if capture_paths:
+        return capture_paths
+    path_list = ", ".join(str(path) for path in config.input.paths) or "<none>"
+    raise ExperimentRunError(
+        "No capture files found for input path(s): "
+        f"{path_list}. Expected .pcap, .pcapng, or .cap files."
+    )
+
+
+def _target_registry(config: AppConfig) -> TargetRegistry:
+    if config.target_registry_path is None:
+        raise ExperimentRunError("target_registry_path is required")
+    return TargetRegistry.from_file(config.target_registry_path)
+
+
+def _target_registry_optional(config: AppConfig) -> TargetRegistry | None:
+    if config.target_registry_path is None:
+        return None
+    return TargetRegistry.from_file(config.target_registry_path)
+
+
+def _default_rolling_target_class(config: AppConfig) -> str:
+    if config.labeling.mode in {"binary_one_vs_rest", "per_target_binary"}:
+        return config.labeling.positive_label
+    return config.labeling.target_id or config.labeling.positive_label
+
+
+def _require_stage_in_profile(stage: str, stages: list[StageName], profile: str) -> None:
+    if stage not in stages:
+        raise ValueError(f"Stage {stage!r} is not part of profile {profile!r}")
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from peekaboo.cli import app
 def test_cli_help_smoke():
     result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
+    assert "run" in result.output
     assert "inspect" in result.output
     assert "ingest" in result.output
     assert "presence-replay" in result.output

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,246 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from peekaboo.capture.synthetic import IPHONE_MAC, write_synthetic_capture
+from peekaboo.cli import app
+from peekaboo.config import AppConfig, DataConfig
+from peekaboo.data.readers import read_all_rows, read_json
+from peekaboo.features.extract import row_to_model_features
+from peekaboo.runner import plan_stages, stage_outputs_exist
+
+pytest.importorskip("scapy")
+
+
+def test_plan_stages_profiles_and_slices():
+    assert plan_stages(profile="full") == [
+        "inspect",
+        "ingest",
+        "features",
+        "label",
+        "split",
+        "train",
+        "eval",
+        "classify",
+        "presence",
+        "report",
+    ]
+    assert plan_stages(profile="prepare") == ["inspect", "ingest", "features", "label", "split"]
+    assert plan_stages(profile="train-eval") == ["train", "eval", "classify", "report"]
+    assert plan_stages(profile="full", from_stage="features", to_stage="train") == [
+        "features",
+        "label",
+        "split",
+        "train",
+    ]
+    with pytest.raises(ValueError, match="not part of profile"):
+        plan_stages(profile="presence-replay", from_stage="inspect")
+
+
+def test_stage_outputs_exist_requires_all_outputs(tmp_path: Path):
+    config = AppConfig(
+        output_dir=tmp_path,
+        data=DataConfig(
+            normalized_path=tmp_path / "records.parquet",
+            features_path=tmp_path / "features.parquet",
+            labeled_path=tmp_path / "labeled.parquet",
+            train_path=tmp_path / "train.parquet",
+            test_path=tmp_path / "test.parquet",
+            predictions_path=tmp_path / "predictions.parquet",
+            rolling_path=tmp_path / "rolling.parquet",
+            metrics_path=tmp_path / "metrics.json",
+        ),
+    )
+
+    assert not stage_outputs_exist(config, "inspect")
+    (tmp_path / "inspect.json").write_text("{}", encoding="utf-8")
+    assert not stage_outputs_exist(config, "inspect")
+    (tmp_path / "inspect.md").write_text("# inspect\n", encoding="utf-8")
+    assert stage_outputs_exist(config, "inspect")
+
+
+def test_run_dry_run_prints_plan_without_artifacts(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_config(config_path, targets_path, capture_path, output_dir)
+
+    result = CliRunner().invoke(app, ["run", "--config", str(config_path), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run planned stages" in result.output
+    assert "inspect -> ingest -> features" in result.output
+    assert not output_dir.exists()
+
+
+def test_run_full_synthetic_pipeline_outputs_manifest_and_artifacts(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_config(config_path, targets_path, capture_path, output_dir)
+
+    result = CliRunner().invoke(app, ["run", "--config", str(config_path), "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    records = read_all_rows(output_dir / "records.parquet")
+    features = read_all_rows(output_dir / "features.parquet")
+    labels = read_all_rows(output_dir / "labeled.parquet")
+    train_rows = read_all_rows(output_dir / "train.parquet")
+    test_rows = read_all_rows(output_dir / "test.parquet")
+    predictions = read_all_rows(output_dir / "predictions.parquet")
+    rolling = read_all_rows(output_dir / "rolling.parquet")
+    replay_predictions = read_all_rows(output_dir / "replay_predictions.jsonl")
+    replay_presence = read_all_rows(output_dir / "replay_presence.jsonl")
+    manifest = read_json(output_dir / "run_manifest.json")
+
+    assert len(records) == 120
+    assert len(features) == 120
+    assert len(labels) == 120
+    assert train_rows
+    assert test_rows
+    assert predictions
+    assert rolling
+    assert replay_predictions
+    assert replay_presence
+    assert (output_dir / "inspect.json").exists()
+    assert (output_dir / "inspect.md").exists()
+    assert (output_dir / "model.pkl").exists()
+    assert (output_dir / "metrics.json").exists()
+    assert (output_dir / "report.md").exists()
+    assert (output_dir / "run_summary.md").exists()
+    assert manifest["status"] == "completed"
+    assert [stage["name"] for stage in manifest["stages"]] == manifest["stage_order"]
+
+    feature_payload = json.loads(predictions[0]["features_json"])
+    assert "source_mac" not in feature_payload
+    assert "destination_mac" not in feature_payload
+    model_features = row_to_model_features(features[0], AppConfig().features)
+    assert "source_mac" not in model_features
+    assert "destination_mac" not in model_features
+
+
+def test_run_skip_existing_and_force_behavior(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_config(config_path, targets_path, capture_path, output_dir)
+    runner = CliRunner()
+
+    first = runner.invoke(app, ["run", "--config", str(config_path), "--profile", "prepare"])
+    assert first.exit_code == 0, first.output
+
+    blocked = runner.invoke(app, ["run", "--config", str(config_path), "--profile", "prepare"])
+    assert blocked.exit_code == 1
+    assert "Output files already exist" in blocked.output
+
+    skipped = runner.invoke(
+        app,
+        ["run", "--config", str(config_path), "--profile", "prepare", "--skip-existing"],
+    )
+    assert skipped.exit_code == 0, skipped.output
+    manifest = read_json(output_dir / "run_manifest.json")
+    assert {stage["status"] for stage in manifest["stages"]} == {"skipped"}
+
+    forced = runner.invoke(
+        app,
+        ["run", "--config", str(config_path), "--profile", "prepare", "--force", "--quiet"],
+    )
+    assert forced.exit_code == 0, forced.output
+    manifest = read_json(output_dir / "run_manifest.json")
+    assert {stage["status"] for stage in manifest["stages"]} == {"completed"}
+
+
+def test_run_missing_capture_fails_and_records_manifest(tmp_path: Path):
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    _write_config(config_path, targets_path, tmp_path / "missing.pcap", output_dir)
+
+    result = CliRunner().invoke(app, ["run", "--config", str(config_path)])
+
+    assert result.exit_code == 1
+    assert "No capture files found" in result.output
+    manifest = read_json(output_dir / "run_manifest.json")
+    assert manifest["status"] == "failed"
+    assert manifest["stages"][0]["name"] == "inspect"
+    assert manifest["stages"][0]["status"] == "failed"
+    assert "No capture files found" in manifest["stages"][0]["error"]
+
+
+def _write_config(
+    config_path: Path,
+    targets_path: Path,
+    capture_path: Path,
+    output_dir: Path,
+) -> None:
+    targets_path.write_text(
+        yaml.safe_dump(
+            {
+                "targets": [
+                    {
+                        "target_id": "iphone_5_user1",
+                        "label": "phone",
+                        "mac_addresses": [IPHONE_MAC],
+                        "enabled": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input": {"paths": [str(capture_path)], "live_interface": None},
+                "target_registry_path": str(targets_path),
+                "output_dir": str(output_dir),
+                "random_seed": 42,
+                "features": {
+                    "data_size_mode": "dot11_frame_len",
+                    "leakage_debug": False,
+                    "impute_numeric": -1.0,
+                    "impute_categorical": "missing",
+                },
+                "labeling": {
+                    "mode": "binary_one_vs_rest",
+                    "target_id": "iphone_5_user1",
+                    "positive_label": "target",
+                    "negative_label": "other",
+                },
+                "data": {
+                    "normalized_path": str(output_dir / "records.parquet"),
+                    "features_path": str(output_dir / "features.parquet"),
+                    "labeled_path": str(output_dir / "labeled.parquet"),
+                    "train_path": str(output_dir / "train.parquet"),
+                    "test_path": str(output_dir / "test.parquet"),
+                    "predictions_path": str(output_dir / "predictions.parquet"),
+                    "rolling_path": str(output_dir / "rolling.parquet"),
+                    "metrics_path": str(output_dir / "metrics.json"),
+                },
+                "model": {
+                    "model_id": "leveraging_bag",
+                    "checkpoint_path": str(output_dir / "model.pkl"),
+                    "params": {"n_models": 5, "base_model": {"grace_period": 5}},
+                },
+                "split": {"train_fraction": 0.75, "chronological": True},
+                "windowing": {
+                    "frame_count": 20,
+                    "time_seconds": 20,
+                    "min_frames": 5,
+                    "present_ratio_threshold": 0.3,
+                    "mean_probability_threshold": 0.3,
+                    "max_probability_threshold": 0.8,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Summary

- adds `peekaboo run` for config-driven end-to-end experiment execution
- adds stage planning, profiles, dry-run, force, and skip-existing behavior
- writes `run_manifest.json` and `run_summary.md` with stage status, artifacts, and row counts
- updates the synthetic demo docs to make the one-command path the primary happy path

Closes #17

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- `python examples/generate_synthetic_capture.py`
- `peekaboo run --config configs/synthetic-demo.yaml --quiet`

Manual synthetic run completed 10 stages and produced 120 records, 120 predictions, 120 replay predictions, and 12 replay presence events.

## Safety

This remains passive-only and metadata-only. The runner only orchestrates existing offline/replay pipeline stages and does not decrypt traffic, inspect payloads, inject frames, probe networks, configure adapters, or channel hop.