### PR TITLE
[codex] Add local capture onboarding wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ All commands accept a YAML config and targeted path/model overrides. Internal da
 
 Run `inspect` before `ingest` on new captures. It checks whether the PCAP inputs contain usable Radiotap and 802.11 metadata, writes `inspect.json` and `inspect.md`, and warns about common first-run problems. If `inspect` or `ingest` reports that no capture files were found, check that the configured `input.paths` exist and contain `.pcap`, `.pcapng`, or `.cap` files.
 
+## Use With Your Own Capture
+
+Only use local captures from networks and devices you are authorized to monitor. Put PCAP/PCAPNG files under an ignored location such as `examples/captures/local/`; the repository ignores captures and generated run outputs by default.
+
+To bootstrap a runnable config and target registry from an authorized capture:
+
+```bash
+peekaboo setup \
+  --input examples/captures/local/home.pcapng \
+  --target-id my_phone \
+  --target-mac aa:bb:cc:dd:ee:ff \
+  --label phone \
+  --output-dir runs/home \
+  --config-output configs/home.yaml \
+  --targets-output configs/home-targets.yaml \
+  --run
+```
+
+`setup` writes `setup_inspect.json` and `setup_candidates.md` under the chosen output directory. If you omit `--target-mac`, it writes the candidate report only, so you can pick a source MAC before generating a target registry. The command does not configure wireless adapters, channel hop, decrypt traffic, inspect payloads, inject frames, or probe networks.
+
 ## Try It With Synthetic Data
 
 The repository includes a generator for a deterministic synthetic Radiotap/802.11 capture. It contains fake MAC addresses and fake frame metadata, so it is safe to use as a first-run demo. The synthetic traffic is intentionally learnable from allowed header-level features such as rate, signal, subtype, and frame size; it is not real-world performance evidence.
@@ -93,6 +113,7 @@ The abstraction leaves room for a later MOA adapter if strict parity is required
 
 ```bash
 peekaboo run
+peekaboo setup
 peekaboo ingest
 peekaboo inspect
 peekaboo features

--- a/src/peekaboo/capture/inspect.py
+++ b/src/peekaboo/capture/inspect.py
@@ -49,6 +49,8 @@ def summarize_packet_records(
     channel_frequencies: set[int] = set()
     source_macs: set[str] = set()
     destination_macs: set[str] = set()
+    source_mac_counts = Counter()
+    destination_mac_counts = Counter()
     target_matches = Counter()
 
     for record in records:
@@ -78,9 +80,13 @@ def summarize_packet_records(
         source_mac = row.get("source_mac")
         destination_mac = row.get("destination_mac")
         if source_mac:
-            source_macs.add(str(source_mac))
+            source_mac_text = str(source_mac)
+            source_macs.add(source_mac_text)
+            source_mac_counts[source_mac_text] += 1
         if destination_mac:
-            destination_macs.add(str(destination_mac))
+            destination_mac_text = str(destination_mac)
+            destination_macs.add(destination_mac_text)
+            destination_mac_counts[destination_mac_text] += 1
         if registry is not None:
             target_id = registry.target_id_for_mac(source_mac)
             if target_id is not None:
@@ -105,6 +111,8 @@ def summarize_packet_records(
         "radiotap_coverage": radiotap_coverage,
         "source_mac_count": len(source_macs),
         "destination_mac_count": len(destination_macs),
+        "source_mac_counts": _sorted_counts(source_mac_counts),
+        "destination_mac_counts": _sorted_counts(destination_mac_counts),
         "target_match_total": sum(target_matches.values()),
         "target_match_counts": dict(sorted(target_matches.items())),
         "warnings": [],
@@ -209,3 +217,7 @@ def _coverage(present: int, total: int) -> dict[str, float | int]:
 def _coverage_fraction(summary: dict[str, Any], field: str) -> float:
     coverage = (summary.get("radiotap_coverage") or {}).get(field) or {}
     return float(coverage.get("coverage") or 0.0)
+
+
+def _sorted_counts(counter: Counter) -> dict[str, int]:
+    return dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))

--- a/src/peekaboo/cli.py
+++ b/src/peekaboo/cli.py
@@ -38,6 +38,7 @@ from peekaboo.labeling.targets import TargetRegistry
 from peekaboo.models.base import load_checkpoint
 from peekaboo.models.registry import create_model
 from peekaboo.runner import ExperimentRunError, run_experiment
+from peekaboo.setup import SetupError, run_setup
 
 app = typer.Typer(no_args_is_help=True, help="Passive 802.11 device identification.")
 
@@ -83,6 +84,54 @@ def run_command(
         f"Run {manifest['status']} with {len(manifest['stages'])} stage(s). "
         f"Wrote {manifest['artifacts']['run_manifest']}"
     )
+
+
+@app.command("setup")
+def setup_command(
+    input_paths: Annotated[
+        list[Path],
+        typer.Option("--input", "-i", help="Authorized PCAP/PCAPNG file or directory."),
+    ],
+    output_dir: Annotated[Path, typer.Option("--output-dir")],
+    config_output: Annotated[Path, typer.Option("--config-output")],
+    targets_output: Annotated[Path, typer.Option("--targets-output")],
+    target_id: Annotated[str | None, typer.Option("--target-id")] = None,
+    target_mac: Annotated[str | None, typer.Option("--target-mac")] = None,
+    label: Annotated[str | None, typer.Option("--label")] = None,
+    run_pipeline: Annotated[bool, typer.Option("--run")] = False,
+    force: Annotated[bool, typer.Option("--force")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+) -> None:
+    try:
+        result = run_setup(
+            input_paths=input_paths,
+            output_dir=output_dir,
+            config_output=config_output,
+            targets_output=targets_output,
+            target_id=target_id,
+            target_mac=target_mac,
+            label=label,
+            run_pipeline=run_pipeline,
+            force=force,
+            quiet=quiet,
+            progress=typer.echo,
+        )
+    except (SetupError, ExperimentRunError) as exc:
+        typer.secho(str(exc), err=True)
+        raise typer.Exit(1) from exc
+
+    if result["status"] == "candidates_only":
+        typer.echo(f"Wrote setup inspection to {result['setup_inspect_path']}")
+        typer.echo(f"Wrote candidate MAC report to {result['candidate_report_path']}")
+        typer.echo("Rerun with --target-id and --target-mac to generate a runnable config.")
+        return
+
+    typer.echo(f"Wrote setup inspection to {result['setup_inspect_path']}")
+    typer.echo(f"Wrote candidate MAC report to {result['candidate_report_path']}")
+    typer.echo(f"Wrote config to {result['config_path']}")
+    typer.echo(f"Wrote target registry to {result['targets_path']}")
+    if result.get("run_manifest_path"):
+        typer.echo(f"Wrote run manifest to {result['run_manifest_path']}")
 
 
 @app.command()

--- a/src/peekaboo/setup.py
+++ b/src/peekaboo/setup.py
@@ -1,0 +1,289 @@
+"""Local capture onboarding helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from peekaboo.capture.inspect import inspect_capture_paths
+from peekaboo.capture.sources import expand_input_paths
+from peekaboo.config import load_config
+from peekaboo.data.writers import write_json
+from peekaboo.labeling.targets import TargetRegistry
+from peekaboo.parsing.dot11 import normalize_mac
+from peekaboo.runner import run_experiment
+
+ProgressCallback = Callable[[str], None]
+
+
+class SetupError(RuntimeError):
+    """Raised when local capture setup cannot complete."""
+
+
+def run_setup(
+    *,
+    input_paths: Iterable[str | Path],
+    output_dir: str | Path,
+    config_output: str | Path,
+    targets_output: str | Path,
+    target_id: str | None = None,
+    target_mac: str | None = None,
+    label: str | None = None,
+    run_pipeline: bool = False,
+    force: bool = False,
+    quiet: bool = False,
+    progress: ProgressCallback | None = None,
+) -> dict[str, Any]:
+    output_path = Path(output_dir)
+    config_path = Path(config_output)
+    targets_path = Path(targets_output)
+    raw_input_paths = [Path(path) for path in input_paths]
+    capture_paths = expand_input_paths(raw_input_paths)
+    if not capture_paths:
+        path_list = ", ".join(str(path) for path in raw_input_paths) or "<none>"
+        raise SetupError(
+            "No capture files found for input path(s): "
+            f"{path_list}. Expected .pcap, .pcapng, or .cap files."
+        )
+
+    normalized_target_mac = _normalize_target_mac(target_mac)
+    resolved_target_id = target_id or "target"
+    resolved_label = label or "device"
+    registry_data = (
+        build_target_registry_data(
+            target_id=resolved_target_id,
+            target_mac=normalized_target_mac,
+            label=resolved_label,
+        )
+        if normalized_target_mac is not None
+        else None
+    )
+    registry = TargetRegistry.from_dict(registry_data) if registry_data is not None else None
+
+    output_path.mkdir(parents=True, exist_ok=True)
+    summary = inspect_capture_paths(capture_paths, registry=registry)
+    inspect_path = output_path / "setup_inspect.json"
+    candidates_path = output_path / "setup_candidates.md"
+    write_json(inspect_path, summary)
+    write_candidate_report(candidates_path, summary)
+
+    result: dict[str, Any] = {
+        "status": "candidates_only",
+        "capture_files": [str(path) for path in capture_paths],
+        "setup_inspect_path": str(inspect_path),
+        "candidate_report_path": str(candidates_path),
+        "config_path": None,
+        "targets_path": None,
+        "run_manifest_path": None,
+    }
+
+    if normalized_target_mac is None:
+        if progress is not None and not quiet:
+            progress(
+                "No --target-mac supplied. Wrote candidate source MACs; rerun setup with "
+                "--target-id and --target-mac to generate a runnable config."
+            )
+        return result
+
+    _ensure_can_write(config_path, force=force)
+    _ensure_can_write(targets_path, force=force)
+    config_data = build_setup_config_data(
+        input_paths=raw_input_paths,
+        output_dir=output_path,
+        target_registry_path=targets_path,
+        target_id=resolved_target_id,
+    )
+    _write_yaml(targets_path, registry_data or {})
+    _write_yaml(config_path, config_data)
+    load_config(config_path)
+    result.update(
+        {
+            "status": "configured",
+            "config_path": str(config_path),
+            "targets_path": str(targets_path),
+        }
+    )
+
+    if progress is not None and not quiet:
+        progress(f"Wrote config to {config_path}")
+        progress(f"Wrote target registry to {targets_path}")
+
+    if run_pipeline:
+        manifest = run_experiment(
+            config_path,
+            force=force,
+            quiet=quiet,
+            progress=progress,
+        )
+        result["status"] = "ran"
+        result["run_manifest_path"] = str(manifest["artifacts"]["run_manifest"])
+    return result
+
+
+def build_target_registry_data(
+    *,
+    target_id: str,
+    target_mac: str,
+    label: str,
+) -> dict[str, Any]:
+    normalized = _normalize_target_mac(target_mac)
+    if normalized is None:
+        raise SetupError(f"Invalid target MAC address: {target_mac}")
+    return {
+        "targets": [
+            {
+                "target_id": target_id,
+                "label": label,
+                "mac_addresses": [normalized],
+                "enabled": True,
+            }
+        ]
+    }
+
+
+def build_setup_config_data(
+    *,
+    input_paths: Iterable[str | Path],
+    output_dir: str | Path,
+    target_registry_path: str | Path,
+    target_id: str,
+) -> dict[str, Any]:
+    output_path = Path(output_dir)
+    return {
+        "input": {
+            "paths": [str(path) for path in input_paths],
+            "live_interface": None,
+        },
+        "target_registry_path": str(target_registry_path),
+        "output_dir": str(output_path),
+        "random_seed": 42,
+        "features": {
+            "data_size_mode": "dot11_frame_len",
+            "leakage_debug": False,
+            "impute_numeric": -1.0,
+            "impute_categorical": "missing",
+        },
+        "labeling": {
+            "mode": "binary_one_vs_rest",
+            "target_id": target_id,
+            "positive_label": "target",
+            "negative_label": "other",
+        },
+        "filters": {
+            "known_targets_only": False,
+            "include_ap_originated": True,
+            "include_management": True,
+            "include_control": True,
+            "include_data": True,
+            "channel_frequency": None,
+            "start_time": None,
+            "end_time": None,
+            "rssi_min": None,
+            "rssi_max": None,
+            "min_frame_size": None,
+            "ap_macs": [],
+        },
+        "model": {
+            "model_id": "leveraging_bag",
+            "checkpoint_path": str(output_path / "model.pkl"),
+            "params": {"n_models": 5, "base_model": {"grace_period": 5}},
+        },
+        "data": {
+            "normalized_path": str(output_path / "records.parquet"),
+            "features_path": str(output_path / "features.parquet"),
+            "labeled_path": str(output_path / "labeled.parquet"),
+            "train_path": str(output_path / "train.parquet"),
+            "test_path": str(output_path / "test.parquet"),
+            "predictions_path": str(output_path / "predictions.parquet"),
+            "rolling_path": str(output_path / "rolling.parquet"),
+            "metrics_path": str(output_path / "metrics.json"),
+        },
+        "sampling": {
+            "percentage": 100,
+            "balance_strategy": "none",
+            "class_weight_column": "sample_weight",
+        },
+        "split": {
+            "train_fraction": 0.75,
+            "chronological": True,
+        },
+        "windowing": {
+            "frame_count": 20,
+            "time_seconds": 20,
+            "min_frames": 5,
+            "present_ratio_threshold": 0.3,
+            "mean_probability_threshold": 0.3,
+            "max_probability_threshold": 0.8,
+        },
+    }
+
+
+def write_candidate_report(path: str | Path, summary: dict[str, Any]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    channels = ", ".join(map(str, summary.get("channel_frequencies") or [])) or "none"
+    lines = [
+        "# peekaboo Setup Candidates",
+        "",
+        "## Capture Summary",
+        "",
+        f"- Capture files: `{summary.get('capture_file_count', 0)}`",
+        f"- Packets scanned: `{summary.get('packets_scanned', 0)}`",
+        f"- Dot11 frames: `{summary.get('dot11_frame_count', 0)}`",
+        f"- Protected frames: `{summary.get('protected_frame_count', 0)}`",
+        f"- Channel frequencies: `{channels}`",
+        "",
+        "## Source MAC Candidates",
+        "",
+        "| Rank | Source MAC | Frames |",
+        "| ---: | --- | ---: |",
+    ]
+    source_counts = summary.get("source_mac_counts") or {}
+    if source_counts:
+        for index, (mac, count) in enumerate(source_counts.items(), start=1):
+            lines.append(f"| {index} | `{mac}` | {count} |")
+    else:
+        lines.append("| - | No source MACs observed | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "## Next Step",
+            "",
+            (
+                "Choose a MAC address for a device you are authorized to identify, then rerun "
+                "`peekaboo setup` with `--target-id` and `--target-mac`."
+            ),
+            "",
+            "## Warnings",
+            "",
+        ]
+    )
+    warnings = summary.get("warnings") or []
+    if warnings:
+        lines.extend(f"- {warning}" for warning in warnings)
+    else:
+        lines.append("- None")
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _ensure_can_write(path: Path, *, force: bool) -> None:
+    if path.exists() and not force:
+        raise SetupError(f"{path} already exists; use --force to overwrite it.")
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _normalize_target_mac(mac: str | None) -> str | None:
+    if mac is None:
+        return None
+    normalized = normalize_mac(mac)
+    if normalized is None:
+        raise SetupError(f"Invalid target MAC address: {mac}")
+    return normalized

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ def test_cli_help_smoke():
     result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "run" in result.output
+    assert "setup" in result.output
     assert "inspect" in result.output
     assert "ingest" in result.output
     assert "presence-replay" in result.output

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,236 @@
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from peekaboo.capture.synthetic import IPHONE_MAC, write_synthetic_capture
+from peekaboo.cli import app
+from peekaboo.config import load_config
+from peekaboo.data.readers import read_all_rows, read_json
+from peekaboo.labeling.targets import TargetRegistry
+from peekaboo.setup import build_setup_config_data, build_target_registry_data
+
+pytest.importorskip("scapy")
+
+
+def test_setup_config_generation_roots_outputs_under_output_dir(tmp_path: Path):
+    output_dir = tmp_path / "runs" / "home"
+    config_data = build_setup_config_data(
+        input_paths=[tmp_path / "captures"],
+        output_dir=output_dir,
+        target_registry_path=tmp_path / "configs" / "home-targets.yaml",
+        target_id="my_phone",
+    )
+
+    assert config_data["features"]["leakage_debug"] is False
+    assert config_data["labeling"]["target_id"] == "my_phone"
+    for value in config_data["data"].values():
+        assert Path(value).is_relative_to(output_dir)
+    assert Path(config_data["model"]["checkpoint_path"]).is_relative_to(output_dir)
+
+
+def test_target_registry_generation_loads_multi_module_match():
+    registry_data = build_target_registry_data(
+        target_id="my_phone",
+        target_mac="AA:BB:CC:DD:EE:FF",
+        label="phone",
+    )
+    registry = TargetRegistry.from_dict(registry_data)
+
+    assert registry.target_id_for_mac("aa:bb:cc:dd:ee:ff") == "my_phone"
+    assert registry_data["targets"][0]["label"] == "phone"
+    assert registry_data["targets"][0]["mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
+
+
+def test_setup_with_target_writes_config_registry_and_candidates(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    output_dir = tmp_path / "runs" / "home"
+    config_path = tmp_path / "configs" / "home.yaml"
+    targets_path = tmp_path / "configs" / "home-targets.yaml"
+    write_synthetic_capture(capture_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "setup",
+            "--input",
+            str(capture_path),
+            "--output-dir",
+            str(output_dir),
+            "--config-output",
+            str(config_path),
+            "--targets-output",
+            str(targets_path),
+            "--target-id",
+            "my_phone",
+            "--target-mac",
+            IPHONE_MAC,
+            "--label",
+            "phone",
+            "--quiet",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert config_path.exists()
+    assert targets_path.exists()
+    assert (output_dir / "setup_inspect.json").exists()
+    assert (output_dir / "setup_candidates.md").exists()
+    config = load_config(config_path)
+    registry = TargetRegistry.from_file(targets_path)
+    summary = read_json(output_dir / "setup_inspect.json")
+    candidates_text = (output_dir / "setup_candidates.md").read_text(encoding="utf-8")
+
+    assert config.output_dir == output_dir
+    assert config.features.leakage_debug is False
+    assert registry.target_id_for_mac(IPHONE_MAC) == "my_phone"
+    assert summary["target_match_total"] > 0
+    assert IPHONE_MAC in summary["source_mac_counts"]
+    assert IPHONE_MAC in candidates_text
+
+
+def test_setup_run_executes_full_pipeline_and_preserves_feature_policy(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    output_dir = tmp_path / "runs" / "home"
+    config_path = tmp_path / "configs" / "home.yaml"
+    targets_path = tmp_path / "configs" / "home-targets.yaml"
+    write_synthetic_capture(capture_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "setup",
+            "--input",
+            str(capture_path),
+            "--output-dir",
+            str(output_dir),
+            "--config-output",
+            str(config_path),
+            "--targets-output",
+            str(targets_path),
+            "--target-id",
+            "my_phone",
+            "--target-mac",
+            IPHONE_MAC,
+            "--run",
+            "--quiet",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (output_dir / "run_manifest.json").exists()
+    labels = read_all_rows(output_dir / "labeled.parquet")
+    predictions = read_all_rows(output_dir / "predictions.parquet")
+    manifest = read_json(output_dir / "run_manifest.json")
+
+    assert manifest["status"] == "completed"
+    assert any(row["source_mac"] == IPHONE_MAC for row in labels)
+    feature_payload = json.loads(predictions[0]["features_json"])
+    assert "source_mac" not in feature_payload
+    assert "destination_mac" not in feature_payload
+
+
+def test_setup_missing_capture_fails_with_no_capture_wording(tmp_path: Path):
+    result = CliRunner().invoke(
+        app,
+        [
+            "setup",
+            "--input",
+            str(tmp_path / "missing.pcap"),
+            "--output-dir",
+            str(tmp_path / "runs" / "home"),
+            "--config-output",
+            str(tmp_path / "configs" / "home.yaml"),
+            "--targets-output",
+            str(tmp_path / "configs" / "home-targets.yaml"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "No capture files found" in result.output
+
+
+def test_setup_existing_config_and_targets_require_force(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    output_dir = tmp_path / "runs" / "home"
+    config_path = tmp_path / "configs" / "home.yaml"
+    targets_path = tmp_path / "configs" / "home-targets.yaml"
+    write_synthetic_capture(capture_path)
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("existing: true\n", encoding="utf-8")
+    targets_path.write_text("existing: true\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "setup",
+            "--input",
+            str(capture_path),
+            "--output-dir",
+            str(output_dir),
+            "--config-output",
+            str(config_path),
+            "--targets-output",
+            str(targets_path),
+            "--target-id",
+            "my_phone",
+            "--target-mac",
+            IPHONE_MAC,
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "already exists" in result.output
+
+    forced = CliRunner().invoke(
+        app,
+        [
+            "setup",
+            "--input",
+            str(capture_path),
+            "--output-dir",
+            str(output_dir),
+            "--config-output",
+            str(config_path),
+            "--targets-output",
+            str(targets_path),
+            "--target-id",
+            "my_phone",
+            "--target-mac",
+            IPHONE_MAC,
+            "--force",
+        ],
+    )
+    assert forced.exit_code == 0, forced.output
+
+
+def test_setup_without_target_mac_writes_candidates_only(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    output_dir = tmp_path / "runs" / "home"
+    config_path = tmp_path / "configs" / "home.yaml"
+    targets_path = tmp_path / "configs" / "home-targets.yaml"
+    write_synthetic_capture(capture_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "setup",
+            "--input",
+            str(capture_path),
+            "--output-dir",
+            str(output_dir),
+            "--config-output",
+            str(config_path),
+            "--targets-output",
+            str(targets_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Rerun with --target-id and --target-mac" in result.output
+    assert (output_dir / "setup_inspect.json").exists()
+    assert (output_dir / "setup_candidates.md").exists()
+    assert not config_path.exists()
+    assert not targets_path.exists()
+    assert IPHONE_MAC in (output_dir / "setup_candidates.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- adds `peekaboo setup` to inspect authorized local captures and bootstrap runnable configs
- writes `setup_inspect.json` and `setup_candidates.md` with source-MAC candidate counts
- creates target registry/config outputs when `--target-mac` is supplied
- optionally runs the existing one-command experiment runner via `--run`
- documents the safe local-capture onboarding workflow

Closes #19

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- `python examples/generate_synthetic_capture.py`
- `peekaboo setup --input examples/captures/synthetic-demo.pcap --target-id my_phone --target-mac aa:bb:cc:dd:ee:ff --label phone --output-dir runs/home --config-output configs/home.yaml --targets-output configs/home-targets.yaml --run --quiet`

Manual synthetic setup found 40 target matches and the optional run completed with 120 records, 120 predictions, and 12 replay presence events.

## Safety

This remains passive-only and metadata-only. Setup only inspects authorized PCAP inputs and writes local config/registry files; it does not decrypt traffic, inspect payloads, inject frames, probe networks, configure adapters, or channel hop.