### PR TITLE
[codex] Add coverage reporting and gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Compile
         run: python -m compileall -q src tests
 
-      - name: Test
+      - name: Test with coverage
         run: python -m pytest -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,13 @@ Run the same checks used by CI:
 make check PYTHON=.venv/bin/python
 ```
 
+`make test` and `make check` both report coverage for `src/peekaboo` and fail if coverage drops below the configured gate. To generate an HTML coverage report:
+
+```bash
+make coverage PYTHON=.venv/bin/python
+open htmlcov/index.html
+```
+
 Useful individual commands:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: install test lint check build clean
+.PHONY: install test lint check coverage build clean
 
 install:
 	$(PYTHON) -m pip install -e ".[dev]"
@@ -15,9 +15,12 @@ check: lint
 	$(PYTHON) -m compileall -q src tests
 	$(PYTHON) -m pytest -q
 
+coverage:
+	$(PYTHON) -m pytest -q --cov-report=term-missing --cov-report=html
+
 build:
 	$(PYTHON) -m build
 
 clean:
-	rm -rf build dist *.egg-info .pytest_cache .ruff_cache htmlcov .coverage
+	rm -rf build dist *.egg-info .pytest_cache .ruff_cache htmlcov .coverage coverage.xml
 	find . -type d -name __pycache__ -prune -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ source .venv/bin/activate
 python -m pip install -e ".[dev]"
 ```
 
+## Local Checks
+
+```bash
+make check PYTHON=.venv/bin/python
+```
+
+The test command reports coverage for `src/peekaboo` and enforces the configured coverage gate. Use `make coverage PYTHON=.venv/bin/python` for an HTML report under `htmlcov/`.
+
 ## Quick Start
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "build>=1.2",
+  "pytest-cov>=7.0",
   "pytest>=9.0.3",
   "ruff>=0.4",
 ]
@@ -39,6 +40,27 @@ packages = ["src/peekaboo"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+addopts = [
+  "--cov=src/peekaboo",
+  "--cov-report=term-missing",
+  "--cov-fail-under=70",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["src/peekaboo"]
+omit = [
+  "src/peekaboo/__init__.py",
+  "src/peekaboo/*/__init__.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+exclude_lines = [
+  "pragma: no cover",
+  'if __name__ == "__main__":',
+]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

- adds `pytest-cov` to the dev extra
- configures coverage reporting for `src/peekaboo`
- adds a modest 70% coverage gate enforced by local pytest and CI
- adds a `make coverage` HTML report target
- documents coverage checks in README and CONTRIBUTING

Closes #21

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- `make coverage PYTHON=.venv/bin/python`

Current local total coverage is 80.49%, above the configured 70% gate.

## Safety

This is test and maintenance-only. It does not change packet parsing, model behavior, live capture behavior, or passive-only guardrails.