### PR TITLE
[codex] Add experiment comparison suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ The repository includes a generator for a deterministic synthetic Radiotap/802.1
 ```bash
 python examples/generate_synthetic_capture.py
 peekaboo run --config configs/synthetic-demo.yaml
+peekaboo compare --config configs/synthetic-demo.yaml
 ```
 
 The generated capture is written under `examples/captures/`, and pipeline outputs are written under `runs/`. Both locations are ignored by Git so real captures and generated datasets are not accidentally committed.
+
+`peekaboo compare` runs the configured paper-style model/fraction comparison over the labeled synthetic dataset and writes aggregate results under `runs/synthetic-demo/comparison/`. Synthetic comparison results are useful for smoke testing and onboarding only; they are not real-world performance evidence.
 
 To run the synthetic demo one stage at a time instead, use:
 
@@ -76,6 +79,7 @@ peekaboo eval-holdout --config configs/synthetic-demo.yaml
 peekaboo classify-file --config configs/synthetic-demo.yaml
 peekaboo presence-replay --config configs/synthetic-demo.yaml
 peekaboo report --config configs/synthetic-demo.yaml
+peekaboo compare --config configs/synthetic-demo.yaml
 ```
 
 After the full demo, `runs/synthetic-demo/` should include:
@@ -92,6 +96,7 @@ After the full demo, `runs/synthetic-demo/` should include:
 - `rolling.parquet`: rolling target-presence summaries
 - `replay_predictions.jsonl` and `replay_presence.jsonl`: live-style replay output
 - `report.md`: Markdown experiment report
+- `comparison/`: aggregate model/fraction comparison results, report, and trend charts
 
 ## Faithful Feature Policy
 
@@ -121,6 +126,7 @@ The abstraction leaves room for a later MOA adapter if strict parity is required
 
 ```bash
 peekaboo run
+peekaboo compare
 peekaboo setup
 peekaboo ingest
 peekaboo inspect
@@ -145,6 +151,12 @@ Runner profiles:
 - `peekaboo run --profile prepare`: inspect through split
 - `peekaboo run --profile train-eval`: train, holdout evaluation, file classification, report
 - `peekaboo run --profile presence-replay`: train and replay presence output
+
+Comparison runs:
+
+- `peekaboo compare --config configs/synthetic-demo.yaml`: compare configured model IDs and train fractions over a labeled dataset
+- `peekaboo compare --models leveraging_bag --models adaptive_hoeffding_tree --train-fractions 0.1 --train-fractions 0.9`: compare a smaller explicit matrix
+- `peekaboo compare --no-prepare`: require an existing labeled dataset instead of preparing missing inputs
 
 `classify-live` is passive-only. It reads from a preconfigured monitor-mode interface and does not perform channel hopping or interface setup.
 

--- a/configs/synthetic-demo.yaml
+++ b/configs/synthetic-demo.yaml
@@ -66,3 +66,17 @@ windowing:
   present_ratio_threshold: 0.3
   mean_probability_threshold: 0.3
   max_probability_threshold: 0.8
+
+comparison:
+  models:
+    - leveraging_bag
+    - oza_boost
+    - oza_boost_adwin
+    - adaptive_hoeffding_tree
+  train_fractions:
+    - 0.01
+    - 0.1
+    - 0.5
+    - 0.9
+  output_dir: runs/synthetic-demo/comparison
+  prepare_if_missing: true

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,9 +5,10 @@ Generate a deterministic synthetic Radiotap/802.11 capture and run the full demo
 ```bash
 python examples/generate_synthetic_capture.py
 peekaboo run --config configs/synthetic-demo.yaml
+peekaboo compare --config configs/synthetic-demo.yaml
 ```
 
-The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, `run_manifest.json`, `run_summary.md`, and Markdown report under `runs/synthetic-demo/`, which is also ignored by Git.
+The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, `run_manifest.json`, `run_summary.md`, Markdown report, and aggregate comparison outputs under `runs/synthetic-demo/`, which is also ignored by Git. Synthetic comparison results are onboarding smoke evidence only, not real-world wireless performance evidence.
 
 To run the same workflow manually one command at a time:
 
@@ -22,6 +23,7 @@ peekaboo eval-holdout --config configs/synthetic-demo.yaml
 peekaboo classify-file --config configs/synthetic-demo.yaml
 peekaboo presence-replay --config configs/synthetic-demo.yaml
 peekaboo report --config configs/synthetic-demo.yaml
+peekaboo compare --config configs/synthetic-demo.yaml
 ```
 
 For real authorized monitor-mode captures, place PCAP or PCAPNG files under `examples/captures/`, then point a config at them. The repository intentionally does not include real wireless captures.

--- a/src/peekaboo/cli.py
+++ b/src/peekaboo/cli.py
@@ -10,6 +10,7 @@ import typer
 from peekaboo.capture.inspect import inspect_capture_paths, write_inspection_markdown
 from peekaboo.capture.live import iter_live_records
 from peekaboo.capture.sources import expand_input_paths, iter_packet_records
+from peekaboo.comparison import ComparisonError, run_comparison
 from peekaboo.config import AppConfig, load_config, write_run_config
 from peekaboo.data.readers import iter_rows
 from peekaboo.data.sampling import balance_file, random_sample_file
@@ -83,6 +84,45 @@ def run_command(
     typer.echo(
         f"Run {manifest['status']} with {len(manifest['stages'])} stage(s). "
         f"Wrote {manifest['artifacts']['run_manifest']}"
+    )
+
+
+@app.command("compare")
+def compare_command(
+    config: ConfigOption,
+    models: Annotated[
+        list[str] | None,
+        typer.Option("--models", help="Model ID to include; repeat for multiple models."),
+    ] = None,
+    train_fractions: Annotated[
+        list[float] | None,
+        typer.Option(
+            "--train-fractions",
+            help="Training fraction to include; repeat for multiple fractions.",
+        ),
+    ] = None,
+    output_dir: Annotated[Path | None, typer.Option("--output-dir")] = None,
+    prepare: Annotated[bool | None, typer.Option("--prepare/--no-prepare")] = None,
+    force: Annotated[bool, typer.Option("--force")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+) -> None:
+    try:
+        manifest = run_comparison(
+            config,
+            models=models,
+            train_fractions=train_fractions,
+            output_dir=output_dir,
+            prepare_if_missing=prepare,
+            force=force,
+            quiet=quiet,
+            progress=typer.echo,
+        )
+    except ComparisonError as exc:
+        typer.secho(str(exc), err=True)
+        raise typer.Exit(1) from exc
+    typer.echo(
+        f"Comparison {manifest['status']} with {manifest['result_count']} result row(s). "
+        f"Wrote {manifest['artifacts']['manifest']}"
     )
 
 

--- a/src/peekaboo/comparison.py
+++ b/src/peekaboo/comparison.py
@@ -1,0 +1,546 @@
+"""Paper-style aggregate experiment comparison."""
+
+from __future__ import annotations
+
+import csv
+import random
+import time
+from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from peekaboo import __version__
+from peekaboo.config import AppConfig, FeatureConfig, load_config
+from peekaboo.data.readers import iter_rows, read_all_rows
+from peekaboo.data.writers import write_json
+from peekaboo.evaluation.holdout import train_online_rows
+from peekaboo.evaluation.metrics import classification_metrics
+from peekaboo.features.extract import model_feature_names, row_to_model_features
+from peekaboo.models.base import OnlineModel
+from peekaboo.models.registry import MODEL_MAPPINGS, create_model
+from peekaboo.runner import ExperimentRunError, run_experiment
+
+ProgressCallback = Callable[[str], None]
+
+METRIC_CHARTS = ("accuracy", "f1", "mcc", "roc_auc", "pr_auc")
+RESULT_FIELDS = [
+    "model_id",
+    "train_fraction",
+    "train_rows",
+    "test_rows",
+    "accuracy",
+    "precision",
+    "recall",
+    "f1",
+    "mcc",
+    "roc_auc",
+    "pr_auc",
+    "model_mapping",
+    "elapsed_seconds",
+]
+
+
+class ComparisonError(RuntimeError):
+    """Raised when an experiment comparison cannot complete."""
+
+
+@dataclass(frozen=True)
+class ComparisonRunPlan:
+    model_id: str
+    train_fraction: float
+
+
+def plan_comparisons(
+    *,
+    models: Iterable[str],
+    train_fractions: Iterable[float],
+) -> list[ComparisonRunPlan]:
+    selected_models = _validate_models(list(models))
+    selected_fractions = _validate_train_fractions(list(train_fractions))
+    return [
+        ComparisonRunPlan(model_id=model_id, train_fraction=train_fraction)
+        for model_id in selected_models
+        for train_fraction in selected_fractions
+    ]
+
+
+def comparison_artifact_paths(output_dir: str | Path) -> dict[str, Path | dict[str, Path]]:
+    output_path = Path(output_dir)
+    return {
+        "manifest": output_path / "comparison_manifest.json",
+        "results_csv": output_path / "comparison_results.csv",
+        "results_json": output_path / "comparison_results.json",
+        "report": output_path / "comparison_report.md",
+        "charts": {
+            metric: output_path / f"comparison_{metric}.png" for metric in METRIC_CHARTS
+        },
+    }
+
+
+def run_comparison(
+    config_path: str | Path,
+    *,
+    models: Iterable[str] | None = None,
+    train_fractions: Iterable[float] | None = None,
+    output_dir: str | Path | None = None,
+    prepare_if_missing: bool | None = None,
+    force: bool = False,
+    quiet: bool = False,
+    progress: ProgressCallback | None = None,
+) -> dict[str, Any]:
+    config = load_config(config_path)
+    selected_models = _validate_models(list(models or config.comparison.models))
+    selected_fractions = _validate_train_fractions(
+        list(train_fractions or config.comparison.train_fractions)
+    )
+    selected_output_dir = Path(output_dir or config.comparison.output_dir or "comparison")
+    prepare = (
+        config.comparison.prepare_if_missing if prepare_if_missing is None else prepare_if_missing
+    )
+    artifacts = comparison_artifact_paths(selected_output_dir)
+    output_paths = _flatten_artifact_paths(artifacts)
+
+    if force:
+        _remove_outputs(output_paths)
+    else:
+        conflicts = [path for path in output_paths if path.exists()]
+        if conflicts:
+            raise ComparisonError(
+                "Comparison output files already exist; use --force to overwrite them: "
+                + ", ".join(str(path) for path in conflicts)
+            )
+
+    manifest = _new_manifest(
+        config=config,
+        config_path=Path(config_path),
+        output_dir=selected_output_dir,
+        models=selected_models,
+        train_fractions=selected_fractions,
+        prepare_if_missing=prepare,
+    )
+
+    try:
+        _ensure_labeled_dataset(
+            config_path=Path(config_path),
+            config=config,
+            prepare_if_missing=prepare,
+            quiet=quiet,
+            progress=progress,
+        )
+        total_rows = sum(1 for _ in iter_rows(config.data.labeled_path))
+        if total_rows == 0:
+            raise ComparisonError(f"Labeled dataset {config.data.labeled_path} has no rows")
+
+        results: list[dict[str, Any]] = []
+        feature_names = model_feature_names(config.features)
+        manifest["feature_names"] = feature_names
+        manifest["labeled_rows"] = total_rows
+        for item in plan_comparisons(models=selected_models, train_fractions=selected_fractions):
+            if progress is not None and not quiet:
+                progress(
+                    f"Comparing {item.model_id} at train_fraction={item.train_fraction:g}"
+                )
+            row = _run_one_comparison(
+                config,
+                item,
+                total_rows=total_rows,
+                feature_names=feature_names,
+            )
+            results.append(row)
+
+        chart_paths = write_comparison_charts(selected_output_dir, results)
+        manifest["status"] = "completed"
+        manifest["ended_at"] = _now()
+        manifest["result_count"] = len(results)
+        manifest["artifacts"] = _manifest_artifacts(artifacts, chart_paths)
+
+        _write_results_csv(Path(artifacts["results_csv"]), results)
+        write_json(Path(artifacts["results_json"]), {"results": results})
+        write_comparison_report(Path(artifacts["report"]), manifest=manifest, results=results)
+        write_json(Path(artifacts["manifest"]), manifest)
+        return manifest
+    except Exception as exc:
+        manifest["status"] = "failed"
+        manifest["ended_at"] = _now()
+        manifest["error"] = str(exc)
+        manifest["artifacts"] = _manifest_artifacts(artifacts, {})
+        write_json(Path(artifacts["manifest"]), manifest)
+        if isinstance(exc, ComparisonError):
+            raise
+        raise ComparisonError(str(exc)) from exc
+
+
+def write_comparison_charts(
+    output_dir: str | Path,
+    results: list[dict[str, Any]],
+) -> dict[str, Path]:
+    try:
+        import matplotlib.pyplot as plt  # type: ignore
+    except Exception:
+        return {}
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    chart_paths: dict[str, Path] = {}
+    by_model: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in results:
+        by_model[str(row["model_id"])].append(row)
+
+    for metric in METRIC_CHARTS:
+        plotted = False
+        fig, ax = plt.subplots(figsize=(6, 4))
+        for model_id, rows in sorted(by_model.items()):
+            points = [
+                (float(row["train_fraction"]), row.get(metric))
+                for row in sorted(rows, key=lambda item: float(item["train_fraction"]))
+                if isinstance(row.get(metric), int | float)
+            ]
+            if not points:
+                continue
+            x_values = [point[0] for point in points]
+            y_values = [float(point[1]) for point in points]
+            ax.plot(x_values, y_values, marker="o", label=model_id)
+            plotted = True
+        if not plotted:
+            plt.close(fig)
+            continue
+        ax.set_xlabel("Training fraction")
+        ax.set_ylabel(metric.replace("_", " ").upper())
+        ax.set_title(f"{metric.replace('_', ' ').title()} by Training Fraction")
+        ax.grid(True, alpha=0.3)
+        ax.legend()
+        fig.tight_layout()
+        chart_path = output_path / f"comparison_{metric}.png"
+        fig.savefig(chart_path)
+        plt.close(fig)
+        chart_paths[metric] = chart_path
+    return chart_paths
+
+
+def write_comparison_report(
+    path: str | Path,
+    *,
+    manifest: dict[str, Any],
+    results: list[dict[str, Any]],
+) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# peekaboo Experiment Comparison",
+        "",
+        "## Summary",
+        "",
+        f"- Status: `{manifest.get('status')}`",
+        f"- Config: `{manifest.get('config_path')}`",
+        f"- Random seed: `{manifest.get('random_seed')}`",
+        f"- Labeled rows: `{manifest.get('labeled_rows', 0)}`",
+        f"- Split mode: `{'chronological' if manifest.get('chronological_split') else 'shuffled'}`",
+        f"- Models: `{', '.join(manifest.get('models', []))}`",
+        (
+            "- Training fractions: "
+            f"`{', '.join(str(item) for item in manifest.get('train_fractions', []))}`"
+        ),
+        "",
+        "Synthetic-demo comparison results are smoke evidence only; they are not real-world "
+        "wireless identification performance evidence.",
+        "",
+    ]
+    if manifest.get("leakage_debug"):
+        lines.extend(
+            [
+                "## Leakage Debug Warning",
+                "",
+                (
+                    "This comparison included MAC-derived model features and should not be treated "
+                    "as a faithful reproduction run."
+                ),
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "## Results",
+            "",
+            (
+                "| Model | Train Fraction | Train Rows | Test Rows | Accuracy | Precision | "
+                "Recall | F1 | MCC | ROC AUC | PR AUC | Seconds |"
+            ),
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for row in results:
+        lines.append(
+            f"| `{row['model_id']}` | {row['train_fraction']:.2f} | "
+            f"{row['train_rows']} | {row['test_rows']} | {_fmt(row.get('accuracy'))} | "
+            f"{_fmt(row.get('precision'))} | {_fmt(row.get('recall'))} | "
+            f"{_fmt(row.get('f1'))} | {_fmt(row.get('mcc'))} | "
+            f"{_fmt(row.get('roc_auc'))} | {_fmt(row.get('pr_auc'))} | "
+            f"{_fmt(row.get('elapsed_seconds'))} |"
+        )
+
+    lines.extend(["", "## Model Mapping", ""])
+    for model_id in manifest.get("models", []):
+        lines.append(f"- `{model_id}`: `{MODEL_MAPPINGS[model_id]}`")
+
+    artifacts = manifest.get("artifacts") or {}
+    if artifacts:
+        lines.extend(["", "## Artifacts", ""])
+        for name, value in artifacts.items():
+            if isinstance(value, dict):
+                for nested_name, nested_value in value.items():
+                    lines.append(f"- `{name}.{nested_name}`: `{nested_value}`")
+            else:
+                lines.append(f"- `{name}`: `{value}`")
+
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_one_comparison(
+    config: AppConfig,
+    item: ComparisonRunPlan,
+    *,
+    total_rows: int,
+    feature_names: list[str],
+) -> dict[str, Any]:
+    model = create_model(
+        item.model_id,
+        feature_names=feature_names,
+        seed=config.random_seed,
+        params=config.model.params,
+    )
+    train_rows, test_rows, expected_train, expected_test = _split_rows_for_fraction(
+        config,
+        total_rows=total_rows,
+        train_fraction=item.train_fraction,
+    )
+    started = time.perf_counter()
+    metrics = _evaluate_holdout_metrics(
+        train_rows,
+        test_rows,
+        model,
+        config.features,
+        positive_label=config.labeling.positive_label,
+        weight_column=config.sampling.class_weight_column,
+    )
+    elapsed = time.perf_counter() - started
+    train_examples = metrics.get("train_examples")
+    test_examples = metrics.get("n_examples")
+    return {
+        "model_id": item.model_id,
+        "train_fraction": item.train_fraction,
+        "train_rows": int(expected_train if train_examples is None else train_examples),
+        "test_rows": int(expected_test if test_examples is None else test_examples),
+        "accuracy": metrics.get("accuracy"),
+        "precision": metrics.get("precision"),
+        "recall": metrics.get("recall"),
+        "f1": metrics.get("f1"),
+        "mcc": metrics.get("mcc"),
+        "roc_auc": metrics.get("roc_auc"),
+        "pr_auc": metrics.get("pr_auc"),
+        "model_mapping": MODEL_MAPPINGS[item.model_id],
+        "elapsed_seconds": round(elapsed, 6),
+    }
+
+
+def _evaluate_holdout_metrics(
+    train_rows: Iterable[dict[str, Any]],
+    test_rows: Iterable[dict[str, Any]],
+    model: OnlineModel,
+    feature_config: FeatureConfig,
+    *,
+    positive_label: str,
+    weight_column: str | None,
+) -> dict[str, Any]:
+    train_count = train_online_rows(
+        train_rows,
+        model,
+        feature_config,
+        weight_column=weight_column,
+    )
+    y_true: list[str] = []
+    y_pred: list[str] = []
+    y_score: list[float] = []
+    for row in test_rows:
+        label = row.get("label")
+        if label is None:
+            continue
+        features = row_to_model_features(row, feature_config)
+        probabilities = model.predict_proba_one(features)
+        prediction = model.predict_one(features)
+        if prediction is None and probabilities:
+            prediction = max(probabilities, key=probabilities.get)
+        prediction = prediction or "__none__"
+        y_true.append(str(label))
+        y_pred.append(str(prediction))
+        y_score.append(float(probabilities.get(positive_label, 0.0)))
+
+    metrics = classification_metrics(y_true, y_pred, y_score=y_score, positive_label=positive_label)
+    metrics["train_examples"] = train_count
+    return metrics
+
+
+def _split_rows_for_fraction(
+    config: AppConfig,
+    *,
+    total_rows: int,
+    train_fraction: float,
+) -> tuple[Iterable[dict[str, Any]], Iterable[dict[str, Any]], int, int]:
+    train_count = int(total_rows * train_fraction)
+    if config.split.chronological:
+
+        def train_rows() -> Iterator[dict[str, Any]]:
+            for index, row in enumerate(iter_rows(config.data.labeled_path)):
+                if index < train_count:
+                    yield row
+
+        def test_rows() -> Iterator[dict[str, Any]]:
+            for index, row in enumerate(iter_rows(config.data.labeled_path)):
+                if index >= train_count:
+                    yield row
+
+        return train_rows(), test_rows(), train_count, total_rows - train_count
+
+    rows = read_all_rows(config.data.labeled_path)
+    rng = random.Random(config.random_seed)
+    rng.shuffle(rows)
+    return rows[:train_count], rows[train_count:], train_count, total_rows - train_count
+
+
+def _ensure_labeled_dataset(
+    *,
+    config_path: Path,
+    config: AppConfig,
+    prepare_if_missing: bool,
+    quiet: bool,
+    progress: ProgressCallback | None,
+) -> None:
+    if config.data.labeled_path.exists():
+        return
+    if not prepare_if_missing:
+        raise ComparisonError(
+            f"Labeled dataset {config.data.labeled_path} does not exist; "
+            "run `peekaboo run --profile prepare` first or pass --prepare."
+        )
+    if progress is not None and not quiet:
+        progress("Preparing labeled dataset through label stage")
+    try:
+        run_experiment(
+            config_path,
+            profile="full",
+            to_stage="label",
+            skip_existing=True,
+            quiet=quiet,
+            progress=progress,
+        )
+    except ExperimentRunError as exc:
+        raise ComparisonError(f"Preparing labeled dataset failed: {exc}") from exc
+    if not config.data.labeled_path.exists():
+        raise ComparisonError(
+            f"Preparing labeled dataset did not create {config.data.labeled_path}"
+        )
+
+
+def _write_results_csv(path: Path, results: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=RESULT_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        for row in results:
+            writer.writerow({field: _csv_value(row.get(field)) for field in RESULT_FIELDS})
+
+
+def _csv_value(value: Any) -> Any:
+    return "" if value is None else value
+
+
+def _validate_models(value: list[str]) -> list[str]:
+    unknown = sorted(set(value) - set(MODEL_MAPPINGS))
+    if unknown:
+        raise ComparisonError(f"Unsupported comparison model id(s): {', '.join(unknown)}")
+    if not value:
+        raise ComparisonError("At least one comparison model is required")
+    return value
+
+
+def _validate_train_fractions(value: list[float]) -> list[float]:
+    if not value:
+        raise ComparisonError("At least one training fraction is required")
+    invalid = [fraction for fraction in value if fraction <= 0 or fraction >= 1]
+    if invalid:
+        raise ComparisonError("Training fractions must satisfy 0 < fraction < 1")
+    return value
+
+
+def _flatten_artifact_paths(artifacts: dict[str, Path | dict[str, Path]]) -> list[Path]:
+    paths: list[Path] = []
+    for value in artifacts.values():
+        if isinstance(value, dict):
+            paths.extend(value.values())
+        else:
+            paths.append(value)
+    return paths
+
+
+def _manifest_artifacts(
+    artifacts: dict[str, Path | dict[str, Path]],
+    generated_charts: dict[str, Path],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for name, value in artifacts.items():
+        if name == "charts":
+            result[name] = {metric: str(path) for metric, path in generated_charts.items()}
+        elif isinstance(value, Path):
+            result[name] = str(value)
+    return result
+
+
+def _remove_outputs(paths: Iterable[Path]) -> None:
+    for path in paths:
+        if path.exists() and path.is_file():
+            path.unlink()
+
+
+def _new_manifest(
+    *,
+    config: AppConfig,
+    config_path: Path,
+    output_dir: Path,
+    models: list[str],
+    train_fractions: list[float],
+    prepare_if_missing: bool,
+) -> dict[str, Any]:
+    return {
+        "status": "running",
+        "package_version": __version__,
+        "config_path": str(config_path),
+        "random_seed": config.random_seed,
+        "labeled_path": str(config.data.labeled_path),
+        "output_dir": str(output_dir),
+        "models": models,
+        "train_fractions": train_fractions,
+        "chronological_split": config.split.chronological,
+        "prepare_if_missing": prepare_if_missing,
+        "leakage_debug": config.features.leakage_debug,
+        "started_at": _now(),
+        "ended_at": None,
+        "feature_names": [],
+        "labeled_rows": 0,
+        "result_count": 0,
+        "artifacts": {},
+    }
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()

--- a/src/peekaboo/config.py
+++ b/src/peekaboo/config.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from peekaboo.models.registry import MODEL_MAPPINGS
 
 
 class InputConfig(BaseModel):
@@ -83,6 +85,33 @@ class WindowConfig(BaseModel):
     max_probability_threshold: float = 0.8
 
 
+class ComparisonConfig(BaseModel):
+    models: list[str] = Field(default_factory=lambda: list(MODEL_MAPPINGS))
+    train_fractions: list[float] = Field(default_factory=lambda: [0.01, 0.1, 0.5, 0.9])
+    output_dir: Path | None = None
+    prepare_if_missing: bool = True
+
+    @field_validator("models")
+    @classmethod
+    def validate_models(cls, value: list[str]) -> list[str]:
+        unknown = sorted(set(value) - set(MODEL_MAPPINGS))
+        if unknown:
+            raise ValueError(f"Unsupported comparison model id(s): {', '.join(unknown)}")
+        if not value:
+            raise ValueError("comparison.models must include at least one model id")
+        return value
+
+    @field_validator("train_fractions")
+    @classmethod
+    def validate_train_fractions(cls, value: list[float]) -> list[float]:
+        if not value:
+            raise ValueError("comparison.train_fractions must include at least one fraction")
+        invalid = [fraction for fraction in value if fraction <= 0 or fraction >= 1]
+        if invalid:
+            raise ValueError("comparison.train_fractions values must satisfy 0 < fraction < 1")
+        return value
+
+
 class AppConfig(BaseModel):
     input: InputConfig = Field(default_factory=InputConfig)
     target_registry_path: Path | None = None
@@ -96,6 +125,13 @@ class AppConfig(BaseModel):
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     split: SplitConfig = Field(default_factory=SplitConfig)
     windowing: WindowConfig = Field(default_factory=WindowConfig)
+    comparison: ComparisonConfig = Field(default_factory=ComparisonConfig)
+
+    @model_validator(mode="after")
+    def default_comparison_output_dir(self) -> AppConfig:
+        if self.comparison.output_dir is None:
+            self.comparison.output_dir = self.output_dir / "comparison"
+        return self
 
 
 def _validate_config(data: dict[str, Any]) -> AppConfig:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ def test_cli_help_smoke():
     result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "run" in result.output
+    assert "compare" in result.output
     assert "setup" in result.output
     assert "inspect" in result.output
     assert "ingest" in result.output

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,0 +1,256 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from peekaboo.capture.synthetic import IPHONE_MAC, write_synthetic_capture
+from peekaboo.cli import app
+from peekaboo.comparison import (
+    ComparisonError,
+    plan_comparisons,
+    write_comparison_charts,
+    write_comparison_report,
+)
+from peekaboo.config import AppConfig, ComparisonConfig
+from peekaboo.data.readers import read_json
+
+pytest.importorskip("scapy")
+
+
+def test_comparison_config_defaults_and_validation(tmp_path: Path):
+    config = AppConfig(output_dir=tmp_path / "runs")
+
+    assert config.comparison.models == [
+        "leveraging_bag",
+        "oza_boost",
+        "oza_boost_adwin",
+        "adaptive_hoeffding_tree",
+    ]
+    assert config.comparison.train_fractions == [0.01, 0.1, 0.5, 0.9]
+    assert config.comparison.output_dir == tmp_path / "runs" / "comparison"
+
+    with pytest.raises(ValueError, match="Unsupported comparison model"):
+        ComparisonConfig(models=["not_a_model"])
+    with pytest.raises(ValueError, match="0 < fraction < 1"):
+        ComparisonConfig(train_fractions=[0.0, 1.0])
+
+
+def test_plan_comparisons_builds_model_fraction_matrix():
+    plan = plan_comparisons(
+        models=["leveraging_bag", "adaptive_hoeffding_tree"],
+        train_fractions=[0.1, 0.9],
+    )
+
+    assert [(item.model_id, item.train_fraction) for item in plan] == [
+        ("leveraging_bag", 0.1),
+        ("leveraging_bag", 0.9),
+        ("adaptive_hoeffding_tree", 0.1),
+        ("adaptive_hoeffding_tree", 0.9),
+    ]
+
+    with pytest.raises(ComparisonError, match="Unsupported comparison model"):
+        plan_comparisons(models=["bad"], train_fractions=[0.5])
+
+
+def test_comparison_report_and_empty_metric_charts(tmp_path: Path):
+    manifest = {
+        "status": "completed",
+        "config_path": "config.yaml",
+        "random_seed": 42,
+        "labeled_rows": 10,
+        "chronological_split": True,
+        "models": ["leveraging_bag"],
+        "train_fractions": [0.5],
+        "leakage_debug": False,
+        "artifacts": {"results_csv": str(tmp_path / "comparison_results.csv")},
+    }
+    results = [
+        {
+            "model_id": "leveraging_bag",
+            "train_fraction": 0.5,
+            "train_rows": 5,
+            "test_rows": 5,
+            "accuracy": None,
+            "precision": None,
+            "recall": None,
+            "f1": None,
+            "mcc": None,
+            "roc_auc": None,
+            "pr_auc": None,
+            "model_mapping": "mapping",
+            "elapsed_seconds": 0.1,
+        }
+    ]
+
+    report_path = tmp_path / "comparison_report.md"
+    write_comparison_report(report_path, manifest=manifest, results=results)
+    chart_paths = write_comparison_charts(tmp_path, results)
+
+    assert "peekaboo Experiment Comparison" in report_path.read_text(encoding="utf-8")
+    assert chart_paths == {}
+
+
+def test_compare_cli_runs_synthetic_model_fraction_matrix(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    comparison_dir = output_dir / "comparison"
+    write_synthetic_capture(capture_path)
+    _write_config(
+        config_path,
+        targets_path,
+        capture_path,
+        output_dir,
+        models=[
+            "leveraging_bag",
+            "oza_boost",
+            "oza_boost_adwin",
+            "adaptive_hoeffding_tree",
+        ],
+        train_fractions=[0.1, 0.5],
+    )
+
+    result = CliRunner().invoke(app, ["compare", "--config", str(config_path), "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    manifest = read_json(comparison_dir / "comparison_manifest.json")
+    results = read_json(comparison_dir / "comparison_results.json")["results"]
+    csv_text = (comparison_dir / "comparison_results.csv").read_text(encoding="utf-8")
+
+    assert manifest["status"] == "completed"
+    assert manifest["result_count"] == 8
+    assert "source_mac" not in manifest["feature_names"]
+    assert "destination_mac" not in manifest["feature_names"]
+    assert {row["model_id"] for row in results} == set(manifest["models"])
+    assert {row["train_fraction"] for row in results} == {0.1, 0.5}
+    assert {"accuracy", "precision", "recall", "f1", "mcc", "roc_auc", "pr_auc"} <= set(
+        results[0]
+    )
+    assert "leveraging_bag" in csv_text
+    assert (comparison_dir / "comparison_report.md").exists()
+    assert any(path.name.startswith("comparison_") for path in comparison_dir.glob("*.png"))
+
+
+def test_compare_no_prepare_requires_existing_labeled_dataset(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_config(config_path, targets_path, capture_path, output_dir)
+
+    result = CliRunner().invoke(app, ["compare", "--config", str(config_path), "--no-prepare"])
+
+    assert result.exit_code == 1
+    assert "Labeled dataset" in result.output
+    assert "run `peekaboo run --profile prepare`" in result.output
+
+
+def test_compare_force_overwrites_existing_outputs(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_config(
+        config_path,
+        targets_path,
+        capture_path,
+        output_dir,
+        models=["leveraging_bag"],
+        train_fractions=[0.5],
+    )
+    runner = CliRunner()
+
+    first = runner.invoke(
+        app,
+        [
+            "compare",
+            "--config",
+            str(config_path),
+            "--models",
+            "leveraging_bag",
+            "--train-fractions",
+            "0.5",
+            "--quiet",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    blocked = runner.invoke(app, ["compare", "--config", str(config_path), "--quiet"])
+    assert blocked.exit_code == 1
+    assert "Comparison output files already exist" in blocked.output
+    forced = runner.invoke(app, ["compare", "--config", str(config_path), "--force", "--quiet"])
+    assert forced.exit_code == 0, forced.output
+
+
+def _write_config(
+    config_path: Path,
+    targets_path: Path,
+    capture_path: Path,
+    output_dir: Path,
+    *,
+    models: list[str] | None = None,
+    train_fractions: list[float] | None = None,
+) -> None:
+    targets_path.write_text(
+        yaml.safe_dump(
+            {
+                "targets": [
+                    {
+                        "target_id": "iphone_5_user1",
+                        "label": "phone",
+                        "mac_addresses": [IPHONE_MAC],
+                        "enabled": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input": {"paths": [str(capture_path)], "live_interface": None},
+                "target_registry_path": str(targets_path),
+                "output_dir": str(output_dir),
+                "random_seed": 42,
+                "features": {
+                    "data_size_mode": "dot11_frame_len",
+                    "leakage_debug": False,
+                    "impute_numeric": -1.0,
+                    "impute_categorical": "missing",
+                },
+                "labeling": {
+                    "mode": "binary_one_vs_rest",
+                    "target_id": "iphone_5_user1",
+                    "positive_label": "target",
+                    "negative_label": "other",
+                },
+                "data": {
+                    "normalized_path": str(output_dir / "records.parquet"),
+                    "features_path": str(output_dir / "features.parquet"),
+                    "labeled_path": str(output_dir / "labeled.parquet"),
+                    "train_path": str(output_dir / "train.parquet"),
+                    "test_path": str(output_dir / "test.parquet"),
+                    "predictions_path": str(output_dir / "predictions.parquet"),
+                    "rolling_path": str(output_dir / "rolling.parquet"),
+                    "metrics_path": str(output_dir / "metrics.json"),
+                },
+                "model": {
+                    "model_id": "leveraging_bag",
+                    "checkpoint_path": str(output_dir / "model.pkl"),
+                    "params": {"n_models": 5, "base_model": {"grace_period": 5}},
+                },
+                "split": {"train_fraction": 0.75, "chronological": True},
+                "comparison": {
+                    "models": models or ["leveraging_bag"],
+                    "train_fractions": train_fractions or [0.5],
+                    "output_dir": str(output_dir / "comparison"),
+                    "prepare_if_missing": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Summary

- adds `peekaboo compare` for paper-style aggregate model/fraction comparisons
- adds `comparison` config defaults and validation for model IDs, train fractions, output directory, and prepare-if-missing behavior
- writes comparison manifest, JSON/CSV results, Markdown report, and metric trend charts
- updates the synthetic demo config and docs with the comparison workflow
- adds unit and CLI integration coverage for comparison planning, reports, charts, prepare behavior, overrides, and force behavior

Closes #23

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- `.venv/bin/python examples/generate_synthetic_capture.py && .venv/bin/peekaboo compare --config configs/synthetic-demo.yaml --force --quiet`

## Safety

This feature is passive-only and metadata-only. It only compares already extracted/labeled header-derived feature rows and may prepare missing labels through the existing passive pipeline. It does not decrypt traffic, inspect payloads, inject frames, probe networks, configure adapters, or perform channel hopping.