### PR TITLE
[codex] Add multi-target presence mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,15 @@ The repository includes a generator for a deterministic synthetic Radiotap/802.1
 python examples/generate_synthetic_capture.py
 peekaboo run --config configs/synthetic-demo.yaml
 peekaboo compare --config configs/synthetic-demo.yaml
+peekaboo run --config configs/synthetic-multitarget.yaml
+peekaboo presence-replay --config configs/synthetic-multitarget.yaml --all-targets
 ```
 
 The generated capture is written under `examples/captures/`, and pipeline outputs are written under `runs/`. Both locations are ignored by Git so real captures and generated datasets are not accidentally committed.
 
 `peekaboo compare` runs the configured paper-style model/fraction comparison over the labeled synthetic dataset and writes aggregate results under `runs/synthetic-demo/comparison/`. Synthetic comparison results are useful for smoke testing and onboarding only; they are not real-world performance evidence.
+
+`configs/synthetic-multitarget.yaml` labels the same synthetic capture as multiclass traffic for `iphone_5_user1`, `lg_tv`, and `other`. Its presence config tracks all enabled registry targets, so replay/live-style output emits separate presence windows for each known target.
 
 To run the synthetic demo one stage at a time instead, use:
 
@@ -97,6 +101,15 @@ After the full demo, `runs/synthetic-demo/` should include:
 - `replay_predictions.jsonl` and `replay_presence.jsonl`: live-style replay output
 - `report.md`: Markdown experiment report
 - `comparison/`: aggregate model/fraction comparison results, report, and trend charts
+
+For multi-target presence, run:
+
+```bash
+peekaboo run --config configs/synthetic-multitarget.yaml
+peekaboo presence-replay --config configs/synthetic-multitarget.yaml --all-targets
+```
+
+Use repeated `--target-class` options to track a subset, for example `--target-class iphone_5_user1 --target-class lg_tv`. `--all-targets` uses enabled target IDs from the target registry and requires a multiclass label mode.
 
 ## Faithful Feature Policy
 
@@ -161,6 +174,8 @@ Comparison runs:
 `classify-live` is passive-only. It reads from a preconfigured monitor-mode interface and does not perform channel hopping or interface setup.
 
 `presence-live` is also passive-only. It loads a trained checkpoint, reads from an already configured monitor-mode interface, prints concise target-presence state changes, and writes streaming JSONL outputs. Use `presence-replay` on prepared feature rows to test the same runtime behavior without live wireless hardware.
+
+Both `presence-replay` and `presence-live` support `--all-targets` for multiclass checkpoints and repeatable `--target-class` options for selected targets. Without those options, they keep the single-target default.
 
 ## Output Artifacts
 

--- a/configs/synthetic-multitarget.yaml
+++ b/configs/synthetic-multitarget.yaml
@@ -1,0 +1,72 @@
+input:
+  paths:
+    - examples/captures/synthetic-demo.pcap
+  live_interface: null
+target_registry_path: configs/targets.yaml
+output_dir: runs/synthetic-multitarget
+random_seed: 42
+
+features:
+  data_size_mode: dot11_frame_len
+  leakage_debug: false
+  impute_numeric: -1.0
+  impute_categorical: missing
+
+labeling:
+  mode: multiclass_with_other
+  target_id: null
+  positive_label: target
+  negative_label: other
+
+filters:
+  known_targets_only: false
+  include_ap_originated: true
+  include_management: true
+  include_control: true
+  include_data: true
+  channel_frequency: null
+  start_time: null
+  end_time: null
+  rssi_min: null
+  rssi_max: null
+  min_frame_size: null
+  ap_macs: []
+
+model:
+  model_id: leveraging_bag
+  checkpoint_path: runs/synthetic-multitarget/model.pkl
+  params:
+    n_models: 5
+    base_model:
+      grace_period: 5
+
+data:
+  normalized_path: runs/synthetic-multitarget/records.parquet
+  features_path: runs/synthetic-multitarget/features.parquet
+  labeled_path: runs/synthetic-multitarget/labeled.parquet
+  train_path: runs/synthetic-multitarget/train.parquet
+  test_path: runs/synthetic-multitarget/test.parquet
+  predictions_path: runs/synthetic-multitarget/predictions.parquet
+  rolling_path: runs/synthetic-multitarget/rolling.parquet
+  metrics_path: runs/synthetic-multitarget/metrics.json
+
+sampling:
+  percentage: 100
+  balance_strategy: none
+  class_weight_column: sample_weight
+
+split:
+  train_fraction: 0.75
+  chronological: true
+
+windowing:
+  frame_count: 20
+  time_seconds: 20
+  min_frames: 5
+  present_ratio_threshold: 0.3
+  mean_probability_threshold: 0.3
+  max_probability_threshold: 0.8
+
+presence:
+  target_classes: []
+  all_targets: true

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,9 +6,13 @@ Generate a deterministic synthetic Radiotap/802.11 capture and run the full demo
 python examples/generate_synthetic_capture.py
 peekaboo run --config configs/synthetic-demo.yaml
 peekaboo compare --config configs/synthetic-demo.yaml
+peekaboo run --config configs/synthetic-multitarget.yaml
+peekaboo presence-replay --config configs/synthetic-multitarget.yaml --all-targets
 ```
 
 The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, `run_manifest.json`, `run_summary.md`, Markdown report, and aggregate comparison outputs under `runs/synthetic-demo/`, which is also ignored by Git. Synthetic comparison results are onboarding smoke evidence only, not real-world wireless performance evidence.
+
+The multi-target demo writes separate multiclass outputs under `runs/synthetic-multitarget/` and emits presence rows for each enabled known target in `configs/targets.yaml`.
 
 To run the same workflow manually one command at a time:
 

--- a/src/peekaboo/cli.py
+++ b/src/peekaboo/cli.py
@@ -26,12 +26,13 @@ from peekaboo.evaluation.prequential import evaluate_prequential_rows
 from peekaboo.evaluation.reports import write_markdown_report
 from peekaboo.features.extract import iter_feature_rows, model_feature_names
 from peekaboo.features.selection import rank_feature_file
-from peekaboo.inference.aggregate import rolling_aggregates
+from peekaboo.inference.aggregate import rolling_aggregates_for_targets
 from peekaboo.inference.classify import classify_row, classify_rows
 from peekaboo.inference.presence import (
+    MultiTargetStreamingPresenceEngine,
     PresenceStateTracker,
-    StreamingPresenceEngine,
     format_presence_event,
+    resolve_presence_target_classes,
 )
 from peekaboo.labeling.filters import passes_filters
 from peekaboo.labeling.labelers import iter_labeled_rows
@@ -442,9 +443,17 @@ def classify_file(
     checkpoint: Annotated[Path | None, typer.Option("--checkpoint")] = None,
     predictions_output: Annotated[Path | None, typer.Option("--predictions-output")] = None,
     rolling_output: Annotated[Path | None, typer.Option("--rolling-output")] = None,
-    target_class: Annotated[str | None, typer.Option("--target-class")] = None,
+    target_class: Annotated[
+        list[str] | None,
+        typer.Option("--target-class", help="Target class to aggregate; repeat for many."),
+    ] = None,
+    all_targets: Annotated[
+        bool | None,
+        typer.Option("--all-targets/--single-target", help="Aggregate all enabled targets."),
+    ] = None,
 ) -> None:
     cfg = load_config(config)
+    target_classes = _presence_target_classes(cfg, target_class, all_targets)
     model = load_checkpoint(checkpoint or cfg.model.checkpoint_path)
     predictions = classify_rows(
         iter_rows(input_path or cfg.data.features_path),
@@ -456,10 +465,16 @@ def classify_file(
     pred_path = predictions_output or cfg.data.predictions_path
     roll_path = rolling_output or cfg.data.rolling_path
     write_rows(pred_path, predictions)
-    target = target_class or _default_rolling_target_class(cfg)
-    rolling = rolling_aggregates(predictions, target_class=target, config=cfg.windowing)
+    rolling = rolling_aggregates_for_targets(
+        predictions,
+        target_classes=target_classes,
+        config=cfg.windowing,
+    )
     write_rows(roll_path, rolling)
-    typer.echo(f"Wrote {len(predictions)} predictions and {len(rolling)} rolling rows")
+    typer.echo(
+        f"Wrote {len(predictions)} predictions and {len(rolling)} rolling rows "
+        f"for {len(target_classes)} target class(es)"
+    )
 
 
 @app.command("presence-replay")
@@ -469,19 +484,27 @@ def presence_replay(
     checkpoint: Annotated[Path | None, typer.Option("--checkpoint")] = None,
     predictions_output: Annotated[Path | None, typer.Option("--predictions-output")] = None,
     presence_output: Annotated[Path | None, typer.Option("--presence-output")] = None,
-    target_class: Annotated[str | None, typer.Option("--target-class")] = None,
+    target_class: Annotated[
+        list[str] | None,
+        typer.Option("--target-class", help="Target class to track; repeat for many."),
+    ] = None,
+    all_targets: Annotated[
+        bool | None,
+        typer.Option("--all-targets/--single-target", help="Track all enabled targets."),
+    ] = None,
     max_packets: Annotated[int | None, typer.Option("--max-packets")] = None,
     quiet: Annotated[bool, typer.Option("--quiet")] = False,
 ) -> None:
     cfg = load_config(config)
     if max_packets is not None and max_packets < 1:
         raise typer.BadParameter("--max-packets must be greater than 0")
+    target_classes = _presence_target_classes(cfg, target_class, all_targets)
     model = load_checkpoint(checkpoint or cfg.model.checkpoint_path)
     prediction_count, event_count = _run_presence_stream(
         iter_rows(input_path or cfg.data.features_path),
         model,
         cfg,
-        target_class=target_class or _default_rolling_target_class(cfg),
+        target_classes=target_classes,
         predictions_output=predictions_output or cfg.output_dir / "replay_predictions.jsonl",
         presence_output=presence_output or cfg.output_dir / "replay_presence.jsonl",
         max_packets=max_packets,
@@ -497,7 +520,14 @@ def presence_live(
     interface: Annotated[str | None, typer.Option("--interface")] = None,
     predictions_output: Annotated[Path | None, typer.Option("--predictions-output")] = None,
     presence_output: Annotated[Path | None, typer.Option("--presence-output")] = None,
-    target_class: Annotated[str | None, typer.Option("--target-class")] = None,
+    target_class: Annotated[
+        list[str] | None,
+        typer.Option("--target-class", help="Target class to track; repeat for many."),
+    ] = None,
+    all_targets: Annotated[
+        bool | None,
+        typer.Option("--all-targets/--single-target", help="Track all enabled targets."),
+    ] = None,
     max_packets: Annotated[int | None, typer.Option("--max-packets")] = None,
     timeout_seconds: Annotated[float | None, typer.Option("--timeout-seconds")] = None,
     quiet: Annotated[bool, typer.Option("--quiet")] = False,
@@ -508,6 +538,7 @@ def presence_live(
         raise typer.BadParameter("A monitor-mode interface is required")
     if max_packets is not None and max_packets < 1:
         raise typer.BadParameter("--max-packets must be greater than 0")
+    target_classes = _presence_target_classes(cfg, target_class, all_targets)
     model = load_checkpoint(checkpoint or cfg.model.checkpoint_path)
     feature_rows = iter_feature_rows(
         iter_live_records(iface, timeout_seconds=timeout_seconds, max_packets=max_packets),
@@ -517,7 +548,7 @@ def presence_live(
         feature_rows,
         model,
         cfg,
-        target_class=target_class or _default_rolling_target_class(cfg),
+        target_classes=target_classes,
         predictions_output=predictions_output or cfg.output_dir / "live_predictions.jsonl",
         presence_output=presence_output or cfg.output_dir / "live_presence.jsonl",
         max_packets=None,
@@ -576,10 +607,19 @@ def _write_run_config(cfg: AppConfig) -> None:
     write_run_config(cfg, cfg.output_dir)
 
 
-def _default_rolling_target_class(cfg: AppConfig) -> str:
-    if cfg.labeling.mode in {"binary_one_vs_rest", "per_target_binary"}:
-        return cfg.labeling.positive_label
-    return cfg.labeling.target_id or cfg.labeling.positive_label
+def _presence_target_classes(
+    cfg: AppConfig,
+    target_classes: list[str] | None,
+    all_targets: bool | None,
+) -> list[str]:
+    try:
+        return resolve_presence_target_classes(
+            cfg,
+            target_classes=target_classes,
+            all_targets=all_targets,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _run_presence_stream(
@@ -587,13 +627,13 @@ def _run_presence_stream(
     model: Any,
     cfg: AppConfig,
     *,
-    target_class: str,
+    target_classes: list[str],
     predictions_output: Path,
     presence_output: Path,
     max_packets: int | None,
     quiet: bool,
 ) -> tuple[int, int]:
-    engine = StreamingPresenceEngine(target_class=target_class, config=cfg.windowing)
+    engine = MultiTargetStreamingPresenceEngine(target_classes=target_classes, config=cfg.windowing)
     state_tracker = PresenceStateTracker()
     prediction_count = 0
     event_count = 0

--- a/src/peekaboo/config.py
+++ b/src/peekaboo/config.py
@@ -85,6 +85,11 @@ class WindowConfig(BaseModel):
     max_probability_threshold: float = 0.8
 
 
+class PresenceConfig(BaseModel):
+    target_classes: list[str] = Field(default_factory=list)
+    all_targets: bool = False
+
+
 class ComparisonConfig(BaseModel):
     models: list[str] = Field(default_factory=lambda: list(MODEL_MAPPINGS))
     train_fractions: list[float] = Field(default_factory=lambda: [0.01, 0.1, 0.5, 0.9])
@@ -125,6 +130,7 @@ class AppConfig(BaseModel):
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     split: SplitConfig = Field(default_factory=SplitConfig)
     windowing: WindowConfig = Field(default_factory=WindowConfig)
+    presence: PresenceConfig = Field(default_factory=PresenceConfig)
     comparison: ComparisonConfig = Field(default_factory=ComparisonConfig)
 
     @model_validator(mode="after")

--- a/src/peekaboo/evaluation/metrics.py
+++ b/src/peekaboo/evaluation/metrics.py
@@ -103,6 +103,8 @@ def binary_auc_metrics(
     except Exception:
         return {"roc_auc": None, "pr_auc": None}
     truth = [1 if label == positive_label else 0 for label in y_true]
+    if len(set(truth)) < 2:
+        return {"roc_auc": None, "pr_auc": None}
     try:
         return {
             "roc_auc": float(roc_auc_score(truth, y_score)),

--- a/src/peekaboo/inference/aggregate.py
+++ b/src/peekaboo/inference/aggregate.py
@@ -62,6 +62,30 @@ def rolling_aggregates(
     config: WindowConfig,
 ) -> list[dict[str, Any]]:
     rows = list(predictions)
+    return rolling_aggregates_for_targets(rows, target_classes=[target_class], config=config)
+
+
+def rolling_aggregates_for_targets(
+    predictions: Iterable[dict[str, Any]],
+    *,
+    target_classes: Iterable[str],
+    config: WindowConfig,
+) -> list[dict[str, Any]]:
+    rows = list(predictions)
+    output: list[dict[str, Any]] = []
+    for target_class in target_classes:
+        output.extend(
+            _rolling_aggregates_one_target(rows, target_class=target_class, config=config)
+        )
+    return output
+
+
+def _rolling_aggregates_one_target(
+    rows: list[dict[str, Any]],
+    *,
+    target_class: str,
+    config: WindowConfig,
+) -> list[dict[str, Any]]:
     frame_rows = rolling_frame_count(rows, target_class=target_class, config=config)
     for row in frame_rows:
         row["window_type"] = "frame_count"

--- a/src/peekaboo/inference/presence.py
+++ b/src/peekaboo/inference/presence.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
-from peekaboo.config import WindowConfig
+from peekaboo.config import AppConfig, WindowConfig
 from peekaboo.inference.aggregate import summarize_presence_window
+from peekaboo.labeling.targets import TargetRegistry
+
+MULTICLASS_LABEL_MODES = {"multiclass_known_targets_only", "multiclass_with_other"}
 
 
 class StreamingPresenceEngine:
@@ -77,6 +81,29 @@ class StreamingPresenceEngine:
         return event
 
 
+class MultiTargetStreamingPresenceEngine:
+    """Run one streaming presence engine per target class."""
+
+    def __init__(self, *, target_classes: Iterable[str], config: WindowConfig) -> None:
+        self.target_classes = unique_target_classes(target_classes)
+        self.engines = {
+            target_class: StreamingPresenceEngine(target_class=target_class, config=config)
+            for target_class in self.target_classes
+        }
+
+    def process(self, prediction: dict[str, Any]) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        for engine in self.engines.values():
+            events.extend(engine.process(prediction))
+        return events
+
+    def flush(self) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        for engine in self.engines.values():
+            events.extend(engine.flush())
+        return events
+
+
 class PresenceStateTracker:
     """Track state changes so terminal output stays concise."""
 
@@ -89,6 +116,38 @@ class PresenceStateTracker:
         previous = self._last_state.get(key)
         self._last_state[key] = state
         return previous != state
+
+
+def resolve_presence_target_classes(
+    config: AppConfig,
+    *,
+    target_classes: Iterable[str] | None = None,
+    all_targets: bool | None = None,
+    registry: TargetRegistry | None = None,
+) -> list[str]:
+    explicit_targets = unique_target_classes(target_classes or [])
+    if explicit_targets:
+        return explicit_targets
+    if all_targets is True:
+        return _all_registry_targets(config, registry=registry)
+    if all_targets is False:
+        return [_default_presence_target_class(config)]
+    if config.presence.target_classes:
+        return unique_target_classes(config.presence.target_classes)
+    if config.presence.all_targets:
+        return _all_registry_targets(config, registry=registry)
+    return [_default_presence_target_class(config)]
+
+
+def unique_target_classes(target_classes: Iterable[str]) -> list[str]:
+    selected: list[str] = []
+    seen: set[str] = set()
+    for target_class in target_classes:
+        value = str(target_class)
+        if value and value not in seen:
+            selected.append(value)
+            seen.add(value)
+    return selected
 
 
 def format_presence_event(event: dict[str, Any]) -> str:
@@ -107,3 +166,29 @@ def _fmt(value: Any) -> str:
     if isinstance(value, float):
         return f"{value:.3f}"
     return str(value)
+
+
+def _all_registry_targets(
+    config: AppConfig,
+    *,
+    registry: TargetRegistry | None,
+) -> list[str]:
+    if config.labeling.mode not in MULTICLASS_LABEL_MODES:
+        raise ValueError(
+            "--all-targets requires a multiclass label mode "
+            "(multiclass_known_targets_only or multiclass_with_other)"
+        )
+    if registry is None:
+        if config.target_registry_path is None:
+            raise ValueError("--all-targets requires target_registry_path")
+        registry = TargetRegistry.from_file(config.target_registry_path)
+    target_classes = sorted(registry.enabled_target_ids())
+    if not target_classes:
+        raise ValueError("--all-targets found no enabled targets in the target registry")
+    return target_classes
+
+
+def _default_presence_target_class(config: AppConfig) -> str:
+    if config.labeling.mode in {"binary_one_vs_rest", "per_target_binary"}:
+        return config.labeling.positive_label
+    return config.labeling.target_id or config.labeling.positive_label

--- a/src/peekaboo/runner.py
+++ b/src/peekaboo/runner.py
@@ -23,9 +23,12 @@ from peekaboo.evaluation.plots import (
 )
 from peekaboo.evaluation.reports import write_markdown_report
 from peekaboo.features.extract import iter_feature_rows, model_feature_names
-from peekaboo.inference.aggregate import rolling_aggregates
+from peekaboo.inference.aggregate import rolling_aggregates_for_targets
 from peekaboo.inference.classify import classify_row, classify_rows
-from peekaboo.inference.presence import StreamingPresenceEngine
+from peekaboo.inference.presence import (
+    MultiTargetStreamingPresenceEngine,
+    resolve_presence_target_classes,
+)
 from peekaboo.labeling.filters import passes_filters
 from peekaboo.labeling.labelers import iter_labeled_rows
 from peekaboo.labeling.targets import TargetRegistry
@@ -377,8 +380,12 @@ def _run_classify_file(config: AppConfig, *, quiet: bool) -> dict[str, int]:
         positive_label=config.labeling.positive_label,
     )
     write_rows(config.data.predictions_path, predictions)
-    target = _default_rolling_target_class(config)
-    rolling = rolling_aggregates(predictions, target_class=target, config=config.windowing)
+    target_classes = _presence_target_classes(config)
+    rolling = rolling_aggregates_for_targets(
+        predictions,
+        target_classes=target_classes,
+        config=config.windowing,
+    )
     write_rows(config.data.rolling_path, rolling)
     return {"predictions": len(predictions), "rolling": len(rolling)}
 
@@ -389,7 +396,7 @@ def _run_presence_replay(config: AppConfig, *, quiet: bool) -> dict[str, int]:
         iter_rows(config.data.features_path),
         model,
         config,
-        target_class=_default_rolling_target_class(config),
+        target_classes=_presence_target_classes(config),
         predictions_output=config.output_dir / "replay_predictions.jsonl",
         presence_output=config.output_dir / "replay_presence.jsonl",
         quiet=quiet,
@@ -409,13 +416,16 @@ def _write_presence_stream(
     model: Any,
     config: AppConfig,
     *,
-    target_class: str,
+    target_classes: list[str],
     predictions_output: Path,
     presence_output: Path,
     quiet: bool,
 ) -> tuple[int, int]:
     del quiet
-    engine = StreamingPresenceEngine(target_class=target_class, config=config.windowing)
+    engine = MultiTargetStreamingPresenceEngine(
+        target_classes=target_classes,
+        config=config.windowing,
+    )
     prediction_count = 0
     event_count = 0
     with JsonlRowWriter(predictions_output) as predictions, JsonlRowWriter(
@@ -578,10 +588,11 @@ def _target_registry_optional(config: AppConfig) -> TargetRegistry | None:
     return TargetRegistry.from_file(config.target_registry_path)
 
 
-def _default_rolling_target_class(config: AppConfig) -> str:
-    if config.labeling.mode in {"binary_one_vs_rest", "per_target_binary"}:
-        return config.labeling.positive_label
-    return config.labeling.target_id or config.labeling.positive_label
+def _presence_target_classes(config: AppConfig) -> list[str]:
+    try:
+        return resolve_presence_target_classes(config)
+    except ValueError as exc:
+        raise ExperimentRunError(str(exc)) from exc
 
 
 def _require_stage_in_profile(stage: str, stages: list[StageName], profile: str) -> None:

--- a/tests/test_metrics_prequential.py
+++ b/tests/test_metrics_prequential.py
@@ -65,3 +65,15 @@ def test_metrics_include_imbalance_metrics():
     assert metrics["recall"] == 0.5
     assert metrics["f1"] > 0
     assert metrics["mcc"] is not None
+
+
+def test_auc_metrics_skip_when_positive_label_is_absent():
+    metrics = classification_metrics(
+        ["iphone_5_user1", "lg_tv", "other"],
+        ["iphone_5_user1", "lg_tv", "other"],
+        y_score=[0.1, 0.2, 0.0],
+        positive_label="target",
+    )
+
+    assert metrics["roc_auc"] is None
+    assert metrics["pr_auc"] is None

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -1,11 +1,16 @@
 import json
 
-from peekaboo.config import WindowConfig
+import pytest
+
+from peekaboo.config import AppConfig, LabelConfig, PresenceConfig, WindowConfig
 from peekaboo.inference.presence import (
+    MultiTargetStreamingPresenceEngine,
     PresenceStateTracker,
     StreamingPresenceEngine,
     format_presence_event,
+    resolve_presence_target_classes,
 )
+from peekaboo.labeling.targets import TargetRegistry
 
 
 def prediction(timestamp: float, predicted_class: str = "target", probability: float = 0.9):
@@ -14,6 +19,17 @@ def prediction(timestamp: float, predicted_class: str = "target", probability: f
         "predicted_class": predicted_class,
         "confidence": probability,
         "probabilities_json": json.dumps({"target": probability, "other": 1 - probability}),
+    }
+
+
+def multiclass_prediction(timestamp: float, predicted_class: str = "iphone_5_user1"):
+    return {
+        "timestamp": timestamp,
+        "predicted_class": predicted_class,
+        "confidence": 0.9,
+        "probabilities_json": json.dumps(
+            {"iphone_5_user1": 0.9, "lg_tv": 0.1, "other": 0.0}
+        ),
     }
 
 
@@ -72,3 +88,92 @@ def test_presence_state_tracker_reports_changes_without_duplicates():
     assert not tracker.is_change(duplicate_event)
     assert tracker.is_change(absent_event)
     assert "state=absent" in format_presence_event(absent_event)
+
+
+def test_presence_target_resolution_precedence_and_all_targets():
+    registry = TargetRegistry.from_dict(
+        {
+            "targets": [
+                {
+                    "target_id": "iphone_5_user1",
+                    "mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                    "enabled": True,
+                },
+                {
+                    "target_id": "lg_tv",
+                    "mac_addresses": ["11:22:33:44:55:66"],
+                    "enabled": True,
+                },
+            ]
+        }
+    )
+    config = AppConfig(
+        labeling=LabelConfig(mode="multiclass_with_other", target_id="configured"),
+        presence=PresenceConfig(target_classes=["from_config"], all_targets=True),
+    )
+
+    assert resolve_presence_target_classes(
+        config,
+        target_classes=["cli", "cli", "second"],
+        all_targets=True,
+        registry=registry,
+    ) == ["cli", "second"]
+    assert resolve_presence_target_classes(
+        config,
+        target_classes=[],
+        all_targets=True,
+        registry=registry,
+    ) == ["iphone_5_user1", "lg_tv"]
+    assert resolve_presence_target_classes(
+        config,
+        target_classes=[],
+        all_targets=False,
+        registry=registry,
+    ) == ["configured"]
+    assert resolve_presence_target_classes(
+        config,
+        target_classes=None,
+        all_targets=None,
+        registry=registry,
+    ) == ["from_config"]
+
+
+def test_all_targets_requires_registry_and_multiclass_mode():
+    with pytest.raises(ValueError, match="multiclass label mode"):
+        resolve_presence_target_classes(
+            AppConfig(labeling=LabelConfig(mode="binary_one_vs_rest")),
+            all_targets=True,
+        )
+
+    with pytest.raises(ValueError, match="target_registry_path"):
+        resolve_presence_target_classes(
+            AppConfig(labeling=LabelConfig(mode="multiclass_with_other")),
+            all_targets=True,
+        )
+
+
+def test_multi_target_streaming_presence_emits_and_flushes_each_target():
+    engine = MultiTargetStreamingPresenceEngine(
+        target_classes=["iphone_5_user1", "lg_tv"],
+        config=WindowConfig(frame_count=2, time_seconds=10, min_frames=1),
+    )
+
+    assert engine.process(multiclass_prediction(1, "iphone_5_user1")) == []
+    events = engine.process(multiclass_prediction(2, "lg_tv"))
+    final_events = engine.flush()
+
+    assert {event["target_id"] for event in events} == {"iphone_5_user1", "lg_tv"}
+    assert {event["window_type"] for event in events} == {"frame_count"}
+    assert {event["target_id"] for event in final_events} == {"iphone_5_user1", "lg_tv"}
+    assert {event["window_type"] for event in final_events} == {"time"}
+    assert all(event["final_window"] for event in final_events)
+
+
+def test_presence_state_tracker_tracks_changes_per_target():
+    tracker = PresenceStateTracker()
+    iphone_event = {"target_id": "iphone_5_user1", "window_type": "frame_count", "state": "present"}
+    lg_event = {"target_id": "lg_tv", "window_type": "frame_count", "state": "present"}
+
+    assert tracker.is_change(iphone_event)
+    assert not tracker.is_change(iphone_event)
+    assert tracker.is_change(lg_event)

--- a/tests/test_presence_cli.py
+++ b/tests/test_presence_cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import yaml
 from typer.testing import CliRunner
 
-from peekaboo.capture.synthetic import write_synthetic_capture
+from peekaboo.capture.synthetic import IPHONE_MAC, LG_TV_MAC, write_synthetic_capture
 from peekaboo.cli import app
 from peekaboo.data.readers import read_all_rows
 from peekaboo.models.base import OnlineModel
@@ -16,6 +16,17 @@ class AlwaysTargetEstimator:
 
     def predict_one(self, x):
         return "target"
+
+    def learn_one(self, x, y):
+        return None
+
+
+class AlwaysIphoneEstimator:
+    def predict_proba_one(self, x):
+        return {"iphone_5_user1": 0.9, "lg_tv": 0.1, "other": 0.0}
+
+    def predict_one(self, x):
+        return "iphone_5_user1"
 
     def learn_one(self, x, y):
         return None
@@ -51,8 +62,99 @@ def test_presence_replay_outputs_jsonl_and_honors_max_packets(tmp_path: Path):
     assert len(predictions) == 25
     assert presence
     assert {row["state"] for row in presence} <= {"present", "absent", "uncertain"}
+    assert {row["target_id"] for row in presence} == {"target"}
     assert "source_mac" not in predictions[0]["features_json"]
     assert "destination_mac" not in predictions[0]["features_json"]
+
+
+def test_multitarget_presence_replay_and_classify_file_outputs_all_targets(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_multitarget_config(config_path, capture_path, output_dir)
+
+    runner = CliRunner()
+    for command in ["ingest", "features", "label", "train-online"]:
+        result = runner.invoke(app, [command, "--config", str(config_path)])
+        assert result.exit_code == 0, result.output
+
+    replay_result = runner.invoke(
+        app,
+        [
+            "presence-replay",
+            "--config",
+            str(config_path),
+            "--all-targets",
+            "--max-packets",
+            "30",
+            "--quiet",
+        ],
+    )
+    classify_result = runner.invoke(
+        app,
+        ["classify-file", "--config", str(config_path), "--all-targets"],
+    )
+
+    assert replay_result.exit_code == 0, replay_result.output
+    assert classify_result.exit_code == 0, classify_result.output
+    predictions = read_all_rows(output_dir / "replay_predictions.jsonl")
+    presence = read_all_rows(output_dir / "replay_presence.jsonl")
+    rolling = read_all_rows(output_dir / "rolling.parquet")
+    assert len(predictions) == 30
+    assert {row["target_id"] for row in presence} == {"iphone_5_user1", "lg_tv"}
+    assert {row["target_id"] for row in rolling} == {"iphone_5_user1", "lg_tv"}
+    assert "source_mac" not in predictions[0]["features_json"]
+    assert "destination_mac" not in predictions[0]["features_json"]
+
+
+def test_presence_replay_repeat_target_class_limits_output(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_multitarget_config(config_path, capture_path, output_dir)
+
+    runner = CliRunner()
+    for command in ["ingest", "features", "label", "train-online"]:
+        result = runner.invoke(app, [command, "--config", str(config_path)])
+        assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        app,
+        [
+            "presence-replay",
+            "--config",
+            str(config_path),
+            "--target-class",
+            "lg_tv",
+            "--max-packets",
+            "20",
+            "--predictions-output",
+            str(output_dir / "subset_predictions.jsonl"),
+            "--presence-output",
+            str(output_dir / "subset_presence.jsonl"),
+            "--quiet",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert {row["target_id"] for row in read_all_rows(output_dir / "subset_presence.jsonl")} == {
+        "lg_tv"
+    }
+
+
+def test_presence_replay_all_targets_rejects_binary_label_mode(tmp_path: Path):
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, tmp_path / "missing.pcap", tmp_path / "runs")
+
+    result = CliRunner().invoke(
+        app,
+        ["presence-replay", "--config", str(config_path), "--all-targets"],
+    )
+
+    assert result.exit_code != 0
+    assert "multiclass label mode" in result.output
 
 
 def test_presence_live_requires_interface(tmp_path: Path):
@@ -108,6 +210,55 @@ def test_presence_live_uses_passive_live_records_without_hardware(tmp_path: Path
     assert read_all_rows(output_dir / "live_presence.jsonl")
 
 
+def test_presence_live_all_targets_uses_passive_live_records_without_hardware(
+    tmp_path: Path,
+    monkeypatch,
+):
+    output_dir = tmp_path / "runs"
+    config_path = tmp_path / "config.yaml"
+    checkpoint_path = output_dir / "model.pkl"
+    _write_multitarget_config(config_path, tmp_path / "missing.pcap", output_dir)
+    OnlineModel("fake", AlwaysIphoneEstimator(), [], {}).save(checkpoint_path)
+
+    def fake_live_records(interface, *, timeout_seconds=None, max_packets=None):
+        del interface, timeout_seconds
+        for index in range(max_packets or 5):
+            yield PacketRecord(
+                timestamp=float(index),
+                source_file="live:test0",
+                packet_index=index,
+                data_rate=54.0,
+                rssi=-40,
+                frame_type=2,
+                frame_subtype=0,
+                source_mac=IPHONE_MAC,
+                destination_mac="ff:ff:ff:ff:ff:ff",
+                dot11_frame_len=128,
+            )
+
+    monkeypatch.setattr("peekaboo.cli.iter_live_records", fake_live_records)
+    result = CliRunner().invoke(
+        app,
+        [
+            "presence-live",
+            "--config",
+            str(config_path),
+            "--interface",
+            "test0",
+            "--all-targets",
+            "--max-packets",
+            "5",
+            "--quiet",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert {row["target_id"] for row in read_all_rows(output_dir / "live_presence.jsonl")} == {
+        "iphone_5_user1",
+        "lg_tv",
+    }
+
+
 def _write_config(config_path: Path, capture_path: Path, output_dir: Path) -> None:
     targets_path = output_dir / "targets.yaml"
     targets_path.parent.mkdir(parents=True, exist_ok=True)
@@ -127,36 +278,76 @@ def _write_config(config_path: Path, capture_path: Path, output_dir: Path) -> No
         encoding="utf-8",
     )
     config_path.write_text(
+        yaml.safe_dump(_base_config(capture_path, output_dir, targets_path)),
+        encoding="utf-8",
+    )
+
+
+def _write_multitarget_config(config_path: Path, capture_path: Path, output_dir: Path) -> None:
+    targets_path = output_dir / "targets.yaml"
+    targets_path.parent.mkdir(parents=True, exist_ok=True)
+    targets_path.write_text(
         yaml.safe_dump(
             {
-                "input": {"paths": [str(capture_path)], "live_interface": None},
-                "target_registry_path": str(targets_path),
-                "output_dir": str(output_dir),
-                "random_seed": 42,
-                "model": {
-                    "model_id": "leveraging_bag",
-                    "checkpoint_path": str(output_dir / "model.pkl"),
-                    "params": {"n_models": 5, "base_model": {"grace_period": 5}},
-                },
-                "data": {
-                    "normalized_path": str(output_dir / "records.parquet"),
-                    "features_path": str(output_dir / "features.parquet"),
-                    "labeled_path": str(output_dir / "labeled.parquet"),
-                    "train_path": str(output_dir / "train.parquet"),
-                    "test_path": str(output_dir / "test.parquet"),
-                    "predictions_path": str(output_dir / "predictions.parquet"),
-                    "rolling_path": str(output_dir / "rolling.parquet"),
-                    "metrics_path": str(output_dir / "metrics.json"),
-                },
-                "windowing": {
-                    "frame_count": 10,
-                    "time_seconds": 10,
-                    "min_frames": 2,
-                    "present_ratio_threshold": 0.3,
-                    "mean_probability_threshold": 0.3,
-                    "max_probability_threshold": 0.8,
-                },
+                "targets": [
+                    {
+                        "target_id": "iphone_5_user1",
+                        "label": "phone",
+                        "mac_addresses": [IPHONE_MAC],
+                        "enabled": True,
+                    },
+                    {
+                        "target_id": "lg_tv",
+                        "label": "tv",
+                        "mac_addresses": [LG_TV_MAC],
+                        "enabled": True,
+                    },
+                ]
             }
         ),
         encoding="utf-8",
     )
+    data = _base_config(capture_path, output_dir, targets_path)
+    data["labeling"] = {
+        "mode": "multiclass_with_other",
+        "target_id": None,
+        "positive_label": "target",
+        "negative_label": "other",
+    }
+    data["presence"] = {"target_classes": [], "all_targets": True}
+    config_path.write_text(
+        yaml.safe_dump(data),
+        encoding="utf-8",
+    )
+
+
+def _base_config(capture_path: Path, output_dir: Path, targets_path: Path) -> dict:
+    return {
+        "input": {"paths": [str(capture_path)], "live_interface": None},
+        "target_registry_path": str(targets_path),
+        "output_dir": str(output_dir),
+        "random_seed": 42,
+        "model": {
+            "model_id": "leveraging_bag",
+            "checkpoint_path": str(output_dir / "model.pkl"),
+            "params": {"n_models": 5, "base_model": {"grace_period": 5}},
+        },
+        "data": {
+            "normalized_path": str(output_dir / "records.parquet"),
+            "features_path": str(output_dir / "features.parquet"),
+            "labeled_path": str(output_dir / "labeled.parquet"),
+            "train_path": str(output_dir / "train.parquet"),
+            "test_path": str(output_dir / "test.parquet"),
+            "predictions_path": str(output_dir / "predictions.parquet"),
+            "rolling_path": str(output_dir / "rolling.parquet"),
+            "metrics_path": str(output_dir / "metrics.json"),
+        },
+        "windowing": {
+            "frame_count": 10,
+            "time_seconds": 10,
+            "min_frames": 2,
+            "present_ratio_threshold": 0.3,
+            "mean_probability_threshold": 0.3,
+            "max_probability_threshold": 0.8,
+        },
+    }


### PR DESCRIPTION
## Summary

- adds multi-target presence resolution with `presence.target_classes`, `presence.all_targets`, repeatable `--target-class`, and `--all-targets/--single-target`
- extends `presence-replay`, `presence-live`, and `classify-file` while preserving default single-target behavior
- adds a multi-target streaming engine and batch rolling aggregation for multiple target classes
- adds `configs/synthetic-multitarget.yaml` and docs for a multiclass synthetic demo
- suppresses ROC/PR AUC calculation when the configured positive label is absent from multiclass truth labels
- adds unit and CLI integration tests for target resolution, all-target validation, multi-target replay/live behavior, and faithful feature exclusion

Closes #25

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- `.venv/bin/python examples/generate_synthetic_capture.py && .venv/bin/peekaboo run --config configs/synthetic-multitarget.yaml --force --quiet && .venv/bin/peekaboo presence-replay --config configs/synthetic-multitarget.yaml --all-targets --quiet`

## Safety

This remains passive-only and metadata-only. The feature only changes how already produced predictions are aggregated into per-target presence windows. It does not decrypt traffic, inspect payloads, inject frames, probe networks, configure adapters, or perform channel hopping.