### PR TITLE
[codex] Add presence calibration and alert tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,18 @@ The repository includes a generator for a deterministic synthetic Radiotap/802.1
 ```bash
 python examples/generate_synthetic_capture.py
 peekaboo run --config configs/synthetic-demo.yaml
+peekaboo calibrate-presence --config configs/synthetic-demo.yaml
 peekaboo compare --config configs/synthetic-demo.yaml
 peekaboo run --config configs/synthetic-multitarget.yaml
+peekaboo calibrate-presence --config configs/synthetic-multitarget.yaml --all-targets
 peekaboo presence-replay --config configs/synthetic-multitarget.yaml --all-targets
 ```
 
 The generated capture is written under `examples/captures/`, and pipeline outputs are written under `runs/`. Both locations are ignored by Git so real captures and generated datasets are not accidentally committed.
 
 `peekaboo compare` runs the configured paper-style model/fraction comparison over the labeled synthetic dataset and writes aggregate results under `runs/synthetic-demo/comparison/`. Synthetic comparison results are useful for smoke testing and onboarding only; they are not real-world performance evidence.
+
+`peekaboo calibrate-presence` uses labeled predictions, or regenerates them from the labeled dataset and checkpoint when needed, to recommend `windowing` thresholds. It writes `calibration_manifest.json`, `calibration_results.csv`, `calibration_results.json`, `calibration_report.md`, `recommended_windowing.yaml`, and best-effort charts under `runs/synthetic-demo/calibration/`. Copy the recommended `windowing` values into an authorized real-capture config before relying on `presence-live`; synthetic calibration is workflow smoke evidence only.
 
 `configs/synthetic-multitarget.yaml` labels the same synthetic capture as multiclass traffic for `iphone_5_user1`, `lg_tv`, and `other`. Its presence config tracks all enabled registry targets, so replay/live-style output emits separate presence windows for each known target.
 
@@ -83,6 +87,7 @@ peekaboo eval-holdout --config configs/synthetic-demo.yaml
 peekaboo classify-file --config configs/synthetic-demo.yaml
 peekaboo presence-replay --config configs/synthetic-demo.yaml
 peekaboo report --config configs/synthetic-demo.yaml
+peekaboo calibrate-presence --config configs/synthetic-demo.yaml
 peekaboo compare --config configs/synthetic-demo.yaml
 ```
 
@@ -100,12 +105,14 @@ After the full demo, `runs/synthetic-demo/` should include:
 - `rolling.parquet`: rolling target-presence summaries
 - `replay_predictions.jsonl` and `replay_presence.jsonl`: live-style replay output
 - `report.md`: Markdown experiment report
+- `calibration/`: presence threshold sweep results, report, recommended windowing YAML, and charts
 - `comparison/`: aggregate model/fraction comparison results, report, and trend charts
 
 For multi-target presence, run:
 
 ```bash
 peekaboo run --config configs/synthetic-multitarget.yaml
+peekaboo calibrate-presence --config configs/synthetic-multitarget.yaml --all-targets
 peekaboo presence-replay --config configs/synthetic-multitarget.yaml --all-targets
 ```
 
@@ -140,6 +147,7 @@ The abstraction leaves room for a later MOA adapter if strict parity is required
 ```bash
 peekaboo run
 peekaboo compare
+peekaboo calibrate-presence
 peekaboo setup
 peekaboo ingest
 peekaboo inspect
@@ -170,6 +178,12 @@ Comparison runs:
 - `peekaboo compare --config configs/synthetic-demo.yaml`: compare configured model IDs and train fractions over a labeled dataset
 - `peekaboo compare --models leveraging_bag --models adaptive_hoeffding_tree --train-fractions 0.1 --train-fractions 0.9`: compare a smaller explicit matrix
 - `peekaboo compare --no-prepare`: require an existing labeled dataset instead of preparing missing inputs
+
+Presence calibration:
+
+- `peekaboo calibrate-presence --config configs/synthetic-demo.yaml`: sweep presence thresholds and recommend `windowing` values
+- `peekaboo calibrate-presence --all-targets --config configs/synthetic-multitarget.yaml`: calibrate all enabled known targets in a multiclass config
+- `peekaboo calibrate-presence --objective mcc --force`: choose thresholds by MCC and overwrite previous calibration artifacts
 
 `classify-live` is passive-only. It reads from a preconfigured monitor-mode interface and does not perform channel hopping or interface setup.
 

--- a/configs/synthetic-demo.yaml
+++ b/configs/synthetic-demo.yaml
@@ -67,6 +67,30 @@ windowing:
   mean_probability_threshold: 0.3
   max_probability_threshold: 0.8
 
+calibration:
+  objective: f1
+  present_ratio_thresholds:
+    - 0.2
+    - 0.3
+    - 0.4
+    - 0.5
+  mean_probability_thresholds:
+    - 0.2
+    - 0.3
+    - 0.4
+    - 0.5
+  max_probability_thresholds:
+    - 0.6
+    - 0.7
+    - 0.8
+    - 0.9
+  window_types:
+    - frame_count
+    - time
+  min_truth_frames: 1
+  prepare_predictions_if_missing: true
+  output_dir: runs/synthetic-demo/calibration
+
 comparison:
   models:
     - leveraging_bag

--- a/configs/synthetic-multitarget.yaml
+++ b/configs/synthetic-multitarget.yaml
@@ -70,3 +70,27 @@ windowing:
 presence:
   target_classes: []
   all_targets: true
+
+calibration:
+  objective: f1
+  present_ratio_thresholds:
+    - 0.2
+    - 0.3
+    - 0.4
+    - 0.5
+  mean_probability_thresholds:
+    - 0.2
+    - 0.3
+    - 0.4
+    - 0.5
+  max_probability_thresholds:
+    - 0.6
+    - 0.7
+    - 0.8
+    - 0.9
+  window_types:
+    - frame_count
+    - time
+  min_truth_frames: 1
+  prepare_predictions_if_missing: true
+  output_dir: runs/synthetic-multitarget/calibration

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,12 +5,14 @@ Generate a deterministic synthetic Radiotap/802.11 capture and run the full demo
 ```bash
 python examples/generate_synthetic_capture.py
 peekaboo run --config configs/synthetic-demo.yaml
+peekaboo calibrate-presence --config configs/synthetic-demo.yaml
 peekaboo compare --config configs/synthetic-demo.yaml
 peekaboo run --config configs/synthetic-multitarget.yaml
+peekaboo calibrate-presence --config configs/synthetic-multitarget.yaml --all-targets
 peekaboo presence-replay --config configs/synthetic-multitarget.yaml --all-targets
 ```
 
-The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, `run_manifest.json`, `run_summary.md`, Markdown report, and aggregate comparison outputs under `runs/synthetic-demo/`, which is also ignored by Git. Synthetic comparison results are onboarding smoke evidence only, not real-world wireless performance evidence.
+The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, `run_manifest.json`, `run_summary.md`, Markdown report, calibration outputs, and aggregate comparison outputs under `runs/synthetic-demo/`, which is also ignored by Git. Synthetic calibration and comparison results are onboarding smoke evidence only, not real-world wireless performance evidence.
 
 The multi-target demo writes separate multiclass outputs under `runs/synthetic-multitarget/` and emits presence rows for each enabled known target in `configs/targets.yaml`.
 
@@ -27,7 +29,8 @@ peekaboo eval-holdout --config configs/synthetic-demo.yaml
 peekaboo classify-file --config configs/synthetic-demo.yaml
 peekaboo presence-replay --config configs/synthetic-demo.yaml
 peekaboo report --config configs/synthetic-demo.yaml
+peekaboo calibrate-presence --config configs/synthetic-demo.yaml
 peekaboo compare --config configs/synthetic-demo.yaml
 ```
 
-For real authorized monitor-mode captures, place PCAP or PCAPNG files under `examples/captures/`, then point a config at them. The repository intentionally does not include real wireless captures.
+For real authorized monitor-mode captures, place PCAP or PCAPNG files under `examples/captures/`, then point a config at them. Run `peekaboo calibrate-presence` on labeled local replay output before relying on `presence-live`; it uses metadata-only predictions and does not decrypt, inspect payloads, inject frames, probe networks, configure adapters, or channel hop. The repository intentionally does not include real wireless captures.

--- a/src/peekaboo/calibration.py
+++ b/src/peekaboo/calibration.py
@@ -1,0 +1,899 @@
+"""Presence threshold calibration over labeled predictions."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from itertools import product
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+import yaml
+
+from peekaboo import __version__
+from peekaboo.config import AppConfig, CalibrationConfig, WindowConfig, load_config
+from peekaboo.data.readers import iter_rows, read_all_rows
+from peekaboo.data.writers import write_json
+from peekaboo.features.extract import model_feature_names
+from peekaboo.inference.aggregate import presence_state_from_stats
+from peekaboo.inference.classify import classify_rows
+from peekaboo.inference.presence import resolve_presence_target_classes
+from peekaboo.models.base import load_checkpoint
+
+ProgressCallback = Callable[[str], None]
+
+OBJECTIVES = {"f1", "mcc", "precision", "recall"}
+WINDOW_TYPES = {"frame_count", "time"}
+CHART_METRICS = ("objective_score", "precision", "recall", "f1", "mcc")
+RESULT_FIELDS = [
+    "scope",
+    "target_id",
+    "window_type",
+    "candidate_index",
+    "present_ratio_threshold",
+    "mean_probability_threshold",
+    "max_probability_threshold",
+    "window_count",
+    "support",
+    "positive_support",
+    "truth_absent_windows",
+    "true_positive",
+    "false_positive",
+    "true_negative",
+    "false_negative",
+    "precision",
+    "recall",
+    "f1",
+    "mcc",
+    "objective",
+    "objective_score",
+]
+
+
+class CalibrationError(RuntimeError):
+    """Raised when presence calibration cannot complete."""
+
+
+@dataclass(frozen=True)
+class ThresholdCandidate:
+    candidate_index: int
+    present_ratio_threshold: float
+    mean_probability_threshold: float
+    max_probability_threshold: float
+
+    def window_config(self, base: WindowConfig) -> WindowConfig:
+        return WindowConfig(
+            frame_count=base.frame_count,
+            time_seconds=base.time_seconds,
+            min_frames=base.min_frames,
+            present_ratio_threshold=self.present_ratio_threshold,
+            mean_probability_threshold=self.mean_probability_threshold,
+            max_probability_threshold=self.max_probability_threshold,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_index": self.candidate_index,
+            "present_ratio_threshold": self.present_ratio_threshold,
+            "mean_probability_threshold": self.mean_probability_threshold,
+            "max_probability_threshold": self.max_probability_threshold,
+        }
+
+
+def calibration_artifact_paths(output_dir: str | Path) -> dict[str, Path | dict[str, Path]]:
+    output_path = Path(output_dir)
+    return {
+        "manifest": output_path / "calibration_manifest.json",
+        "results_csv": output_path / "calibration_results.csv",
+        "results_json": output_path / "calibration_results.json",
+        "report": output_path / "calibration_report.md",
+        "recommended_windowing": output_path / "recommended_windowing.yaml",
+        "charts": {
+            metric: output_path / f"calibration_{metric}.png" for metric in CHART_METRICS
+        },
+    }
+
+
+def run_presence_calibration(
+    config_path: str | Path,
+    *,
+    input_predictions: str | Path | None = None,
+    input_labeled: str | Path | None = None,
+    output_dir: str | Path | None = None,
+    target_classes: Iterable[str] | None = None,
+    all_targets: bool | None = None,
+    objective: str | None = None,
+    force: bool = False,
+    quiet: bool = False,
+    progress: ProgressCallback | None = None,
+) -> dict[str, Any]:
+    config = load_config(config_path)
+    selected_objective = _validate_objective(objective or config.calibration.objective)
+    selected_output_dir = Path(output_dir or config.calibration.output_dir or "calibration")
+    selected_targets = resolve_presence_target_classes(
+        config,
+        target_classes=target_classes,
+        all_targets=all_targets,
+    )
+    artifacts = calibration_artifact_paths(selected_output_dir)
+    output_paths = _flatten_artifact_paths(artifacts)
+
+    if force:
+        _remove_outputs(output_paths)
+    else:
+        conflicts = [path for path in output_paths if path.exists()]
+        if conflicts:
+            raise CalibrationError(
+                "Calibration output files already exist; use --force to overwrite them: "
+                + ", ".join(str(path) for path in conflicts)
+            )
+
+    manifest = _new_manifest(
+        config=config,
+        config_path=Path(config_path),
+        output_dir=selected_output_dir,
+        objective=selected_objective,
+        target_classes=selected_targets,
+    )
+
+    try:
+        if progress is not None and not quiet:
+            progress("Loading calibration predictions")
+        predictions, prediction_source = _load_calibration_predictions(
+            config,
+            input_predictions=Path(input_predictions) if input_predictions else None,
+            input_labeled=Path(input_labeled) if input_labeled else None,
+        )
+        _require_ground_truth(predictions)
+        if not predictions:
+            raise CalibrationError("Calibration predictions are empty")
+
+        candidates = threshold_candidates(config.windowing, config.calibration)
+        window_stats = calibration_window_stats(
+            predictions,
+            target_classes=selected_targets,
+            window_config=config.windowing,
+            window_types=config.calibration.window_types,
+            min_truth_frames=config.calibration.min_truth_frames,
+        )
+        if not window_stats:
+            raise CalibrationError("No calibration windows could be created from the predictions")
+
+        if progress is not None and not quiet:
+            progress(
+                f"Evaluating {len(candidates)} threshold candidate(s) "
+                f"across {len(window_stats)} window(s)"
+            )
+        results = evaluate_calibration_candidates(
+            window_stats,
+            candidates=candidates,
+            base_window_config=config.windowing,
+            objective=selected_objective,
+        )
+        recommendation = recommend_thresholds(results, objective=selected_objective)
+        warnings = calibration_warnings(
+            config=config,
+            predictions=predictions,
+            window_stats=window_stats,
+            recommendation=recommendation,
+        )
+        chart_paths = write_calibration_charts(selected_output_dir, results)
+
+        manifest.update(
+            {
+                "status": "completed",
+                "ended_at": _now(),
+                "prediction_source": prediction_source,
+                "prediction_rows": len(predictions),
+                "window_count": len(window_stats),
+                "candidate_count": len(candidates),
+                "result_count": len(results),
+                "warnings": warnings,
+                "recommendation": recommendation,
+                "artifacts": _manifest_artifacts(artifacts, chart_paths),
+            }
+        )
+        _write_results_csv(Path(artifacts["results_csv"]), results)
+        write_json(Path(artifacts["results_json"]), {"results": results})
+        write_recommended_windowing(
+            Path(artifacts["recommended_windowing"]),
+            base=config.windowing,
+            recommendation=recommendation,
+        )
+        write_calibration_report(
+            Path(artifacts["report"]),
+            manifest=manifest,
+            results=results,
+        )
+        write_json(Path(artifacts["manifest"]), manifest)
+        return manifest
+    except Exception as exc:
+        manifest["status"] = "failed"
+        manifest["ended_at"] = _now()
+        manifest["error"] = str(exc)
+        manifest["artifacts"] = _manifest_artifacts(artifacts, {})
+        Path(artifacts["manifest"]).parent.mkdir(parents=True, exist_ok=True)
+        write_json(Path(artifacts["manifest"]), manifest)
+        if isinstance(exc, CalibrationError):
+            raise
+        raise CalibrationError(str(exc)) from exc
+
+
+def threshold_candidates(
+    window_config: WindowConfig,
+    calibration_config: CalibrationConfig,
+) -> list[ThresholdCandidate]:
+    ratio_values = _with_current_value(
+        calibration_config.present_ratio_thresholds,
+        window_config.present_ratio_threshold,
+    )
+    mean_values = _with_current_value(
+        calibration_config.mean_probability_thresholds,
+        window_config.mean_probability_threshold,
+    )
+    max_values = _with_current_value(
+        calibration_config.max_probability_thresholds,
+        window_config.max_probability_threshold,
+    )
+    return [
+        ThresholdCandidate(
+            candidate_index=index,
+            present_ratio_threshold=ratio,
+            mean_probability_threshold=mean_threshold,
+            max_probability_threshold=max_threshold,
+        )
+        for index, (ratio, mean_threshold, max_threshold) in enumerate(
+            product(ratio_values, mean_values, max_values)
+        )
+    ]
+
+
+def calibration_window_stats(
+    predictions: list[dict[str, Any]],
+    *,
+    target_classes: Iterable[str],
+    window_config: WindowConfig,
+    window_types: Iterable[str],
+    min_truth_frames: int,
+) -> list[dict[str, Any]]:
+    selected_window_types = list(dict.fromkeys(window_types))
+    unknown = sorted(set(selected_window_types) - WINDOW_TYPES)
+    if unknown:
+        raise CalibrationError(f"Unsupported calibration window type(s): {', '.join(unknown)}")
+
+    output: list[dict[str, Any]] = []
+    for target_class in target_classes:
+        if "frame_count" in selected_window_types:
+            output.extend(
+                _frame_count_window_stats(
+                    predictions,
+                    target_class=target_class,
+                    config=window_config,
+                    min_truth_frames=min_truth_frames,
+                )
+            )
+        if "time" in selected_window_types:
+            output.extend(
+                _time_window_stats(
+                    predictions,
+                    target_class=target_class,
+                    config=window_config,
+                    min_truth_frames=min_truth_frames,
+                )
+            )
+    return output
+
+
+def evaluate_calibration_candidates(
+    window_stats: list[dict[str, Any]],
+    *,
+    candidates: list[ThresholdCandidate],
+    base_window_config: WindowConfig,
+    objective: str,
+) -> list[dict[str, Any]]:
+    selected_objective = _validate_objective(objective)
+    results: list[dict[str, Any]] = []
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for stat in window_stats:
+        grouped.setdefault((str(stat["target_id"]), str(stat["window_type"])), []).append(stat)
+
+    for candidate in candidates:
+        config = candidate.window_config(base_window_config)
+        candidate_rows = [
+            _metric_row(
+                windows,
+                candidate=candidate,
+                config=config,
+                objective=selected_objective,
+                target_id=target_id,
+                window_type=window_type,
+                scope="target_window",
+            )
+            for (target_id, window_type), windows in sorted(grouped.items())
+        ]
+        results.extend(candidate_rows)
+        results.append(
+            _metric_row(
+                window_stats,
+                candidate=candidate,
+                config=config,
+                objective=selected_objective,
+                target_id="__all__",
+                window_type="__all__",
+                scope="global",
+            )
+        )
+    return results
+
+
+def recommend_thresholds(results: list[dict[str, Any]], *, objective: str) -> dict[str, Any]:
+    selected_objective = _validate_objective(objective)
+    global_rows = [row for row in results if row.get("scope") == "global"]
+    if not global_rows:
+        raise CalibrationError("No global calibration rows were produced")
+
+    best = max(
+        global_rows,
+        key=lambda row: (
+            _score(row.get("objective_score")),
+            _score(row.get("mcc")),
+            -int(row.get("false_positive") or 0),
+            _score(row.get("recall")),
+            -int(row.get("candidate_index") or 0),
+        ),
+    )
+    return {
+        "objective": selected_objective,
+        "candidate_index": best["candidate_index"],
+        "present_ratio_threshold": best["present_ratio_threshold"],
+        "mean_probability_threshold": best["mean_probability_threshold"],
+        "max_probability_threshold": best["max_probability_threshold"],
+        "metrics": {field: best.get(field) for field in _metric_fields()},
+    }
+
+
+def write_recommended_windowing(
+    path: str | Path,
+    *,
+    base: WindowConfig,
+    recommendation: dict[str, Any],
+) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "windowing": {
+            "frame_count": base.frame_count,
+            "time_seconds": base.time_seconds,
+            "min_frames": base.min_frames,
+            "present_ratio_threshold": recommendation["present_ratio_threshold"],
+            "mean_probability_threshold": recommendation["mean_probability_threshold"],
+            "max_probability_threshold": recommendation["max_probability_threshold"],
+        }
+    }
+    output.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def write_calibration_report(
+    path: str | Path,
+    *,
+    manifest: dict[str, Any],
+    results: list[dict[str, Any]],
+) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    recommendation = manifest.get("recommendation") or {}
+    metrics = recommendation.get("metrics") or {}
+    lines = [
+        "# peekaboo Presence Calibration",
+        "",
+        "## Summary",
+        "",
+        f"- Status: `{manifest.get('status')}`",
+        f"- Config: `{manifest.get('config_path')}`",
+        f"- Objective: `{manifest.get('objective')}`",
+        f"- Target classes: `{', '.join(manifest.get('target_classes', []))}`",
+        f"- Prediction source: `{manifest.get('prediction_source')}`",
+        f"- Prediction rows: `{manifest.get('prediction_rows', 0)}`",
+        f"- Calibration windows: `{manifest.get('window_count', 0)}`",
+        "",
+        "Calibration uses existing metadata-only predictions and labels. It does not decrypt "
+        "traffic, inspect payloads, inject frames, probe networks, configure adapters, or "
+        "channel hop.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Candidate: `{recommendation.get('candidate_index')}`",
+        f"- Present ratio threshold: `{_fmt(recommendation.get('present_ratio_threshold'))}`",
+        f"- Mean probability threshold: `{_fmt(recommendation.get('mean_probability_threshold'))}`",
+        f"- Max probability threshold: `{_fmt(recommendation.get('max_probability_threshold'))}`",
+        f"- Precision: `{_fmt(metrics.get('precision'))}`",
+        f"- Recall: `{_fmt(metrics.get('recall'))}`",
+        f"- F1: `{_fmt(metrics.get('f1'))}`",
+        f"- MCC: `{_fmt(metrics.get('mcc'))}`",
+        "",
+    ]
+    warnings = manifest.get("warnings") or []
+    if warnings:
+        lines.extend(["## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in warnings)
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Top Global Candidates",
+            "",
+            (
+                "| Candidate | Ratio | Mean Probability | Max Probability | Precision | "
+                "Recall | F1 | MCC | FP | FN |"
+            ),
+            "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    global_rows = [row for row in results if row.get("scope") == "global"]
+    sorted_rows = sorted(
+        global_rows,
+        key=lambda row: (
+            _score(row.get("objective_score")),
+            _score(row.get("mcc")),
+            -int(row.get("false_positive") or 0),
+            _score(row.get("recall")),
+        ),
+        reverse=True,
+    )
+    for row in sorted_rows[:10]:
+        lines.append(
+            f"| {row['candidate_index']} | {_fmt(row.get('present_ratio_threshold'))} | "
+            f"{_fmt(row.get('mean_probability_threshold'))} | "
+            f"{_fmt(row.get('max_probability_threshold'))} | "
+            f"{_fmt(row.get('precision'))} | {_fmt(row.get('recall'))} | "
+            f"{_fmt(row.get('f1'))} | {_fmt(row.get('mcc'))} | "
+            f"{row.get('false_positive')} | {row.get('false_negative')} |"
+        )
+
+    artifacts = manifest.get("artifacts") or {}
+    if artifacts:
+        lines.extend(["", "## Artifacts", ""])
+        for name, value in artifacts.items():
+            if isinstance(value, dict):
+                for nested_name, nested_value in value.items():
+                    lines.append(f"- `{name}.{nested_name}`: `{nested_value}`")
+            else:
+                lines.append(f"- `{name}`: `{value}`")
+
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_calibration_charts(
+    output_dir: str | Path,
+    results: list[dict[str, Any]],
+) -> dict[str, Path]:
+    try:
+        import matplotlib.pyplot as plt  # type: ignore
+    except Exception:
+        return {}
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    global_rows = sorted(
+        [row for row in results if row.get("scope") == "global"],
+        key=lambda row: int(row["candidate_index"]),
+    )
+    chart_paths: dict[str, Path] = {}
+    for metric in CHART_METRICS:
+        points = [
+            (int(row["candidate_index"]), row.get(metric))
+            for row in global_rows
+            if isinstance(row.get(metric), int | float)
+        ]
+        if not points:
+            continue
+        fig, ax = plt.subplots(figsize=(7, 4))
+        ax.plot([point[0] for point in points], [float(point[1]) for point in points])
+        ax.set_xlabel("Threshold candidate")
+        ax.set_ylabel(metric.replace("_", " ").title())
+        ax.set_title(f"Calibration {metric.replace('_', ' ').title()}")
+        ax.grid(True, alpha=0.3)
+        fig.tight_layout()
+        chart_path = output_path / f"calibration_{metric}.png"
+        fig.savefig(chart_path)
+        plt.close(fig)
+        chart_paths[metric] = chart_path
+    return chart_paths
+
+
+def calibration_warnings(
+    *,
+    config: AppConfig,
+    predictions: list[dict[str, Any]],
+    window_stats: list[dict[str, Any]],
+    recommendation: dict[str, Any],
+) -> list[str]:
+    warnings: list[str] = []
+    if config.features.leakage_debug:
+        warnings.append(
+            "This run enabled leakage/debug features, so calibrated thresholds are not faithful "
+            "to the default MAC-dropping pipeline."
+        )
+    if _looks_synthetic(config, predictions):
+        warnings.append(
+            "This appears to use synthetic data; treat calibration output as workflow smoke "
+            "evidence, not real-world performance evidence."
+        )
+    truth_present = sum(1 for stat in window_stats if stat["truth_present"])
+    total_windows = len(window_stats)
+    if total_windows < 5:
+        warnings.append("Very few windows were available; threshold recommendations may be sparse.")
+    if total_windows and min(truth_present, total_windows - truth_present) / total_windows < 0.1:
+        warnings.append(
+            "Window truth labels are highly skewed; precision, recall, and MCC may be unstable."
+        )
+    metrics = recommendation.get("metrics") or {}
+    if (metrics.get("false_positive") or 0) > 0 or (metrics.get("false_negative") or 0) > 0:
+        warnings.append(
+            "The recommended threshold still has calibration errors; inspect false positives and "
+            "false negatives before using it for live alerts."
+        )
+    return warnings
+
+
+def _frame_count_window_stats(
+    rows: list[dict[str, Any]],
+    *,
+    target_class: str,
+    config: WindowConfig,
+    min_truth_frames: int,
+) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for start in range(0, len(rows), config.frame_count):
+        chunk = rows[start : start + config.frame_count]
+        if chunk:
+            output.append(
+                _summarize_calibration_window(
+                    chunk,
+                    target_class=target_class,
+                    window_type="frame_count",
+                    window_start=start,
+                    window_end=start + len(chunk) - 1,
+                    min_truth_frames=min_truth_frames,
+                )
+            )
+    return output
+
+
+def _time_window_stats(
+    rows: list[dict[str, Any]],
+    *,
+    target_class: str,
+    config: WindowConfig,
+    min_truth_frames: int,
+) -> list[dict[str, Any]]:
+    buckets: dict[int, list[dict[str, Any]]] = {}
+    for row in rows:
+        timestamp = row.get("timestamp")
+        if timestamp is None:
+            continue
+        bucket = int(float(timestamp) // config.time_seconds)
+        buckets.setdefault(bucket, []).append(row)
+
+    output: list[dict[str, Any]] = []
+    for bucket, chunk in sorted(buckets.items()):
+        output.append(
+            _summarize_calibration_window(
+                chunk,
+                target_class=target_class,
+                window_type="time",
+                window_start=bucket * config.time_seconds,
+                window_end=(bucket + 1) * config.time_seconds,
+                min_truth_frames=min_truth_frames,
+            )
+        )
+    return output
+
+
+def _summarize_calibration_window(
+    rows: list[dict[str, Any]],
+    *,
+    target_class: str,
+    window_type: str,
+    window_start: float | int,
+    window_end: float | int,
+    min_truth_frames: int,
+) -> dict[str, Any]:
+    probabilities = [_target_probability(row, target_class) for row in rows]
+    positive_predictions = [
+        row for row in rows if str(row.get("predicted_class")) == target_class
+    ]
+    truth_count = sum(1 for row in rows if str(row.get("ground_truth")) == target_class)
+    return {
+        "target_id": target_class,
+        "window_type": window_type,
+        "window_start": window_start,
+        "window_end": window_end,
+        "frame_count": len(rows),
+        "positive_prediction_ratio": len(positive_predictions) / len(rows) if rows else None,
+        "mean_probability": mean(probabilities) if probabilities else None,
+        "max_probability": max(probabilities) if probabilities else None,
+        "truth_count": truth_count,
+        "truth_present": truth_count >= min_truth_frames,
+    }
+
+
+def _metric_row(
+    windows: list[dict[str, Any]],
+    *,
+    candidate: ThresholdCandidate,
+    config: WindowConfig,
+    objective: str,
+    target_id: str,
+    window_type: str,
+    scope: str,
+) -> dict[str, Any]:
+    counts = _confusion_counts(windows, config)
+    metrics = _binary_metrics(counts)
+    row: dict[str, Any] = {
+        "scope": scope,
+        "target_id": target_id,
+        "window_type": window_type,
+        **candidate.to_dict(),
+        **counts,
+        **metrics,
+        "objective": objective,
+        "objective_score": metrics.get(objective),
+    }
+    return row
+
+
+def _confusion_counts(
+    windows: list[dict[str, Any]],
+    config: WindowConfig,
+) -> dict[str, int]:
+    tp = fp = tn = fn = 0
+    for stat in windows:
+        state = presence_state_from_stats(
+            int(stat["frame_count"]),
+            stat.get("positive_prediction_ratio"),
+            stat.get("mean_probability"),
+            stat.get("max_probability"),
+            config,
+        )
+        predicted_present = state == "present"
+        truth_present = bool(stat["truth_present"])
+        if predicted_present and truth_present:
+            tp += 1
+        elif predicted_present and not truth_present:
+            fp += 1
+        elif not predicted_present and truth_present:
+            fn += 1
+        else:
+            tn += 1
+    positive_support = tp + fn
+    return {
+        "window_count": len(windows),
+        "support": len(windows),
+        "positive_support": positive_support,
+        "truth_absent_windows": tn + fp,
+        "true_positive": tp,
+        "false_positive": fp,
+        "true_negative": tn,
+        "false_negative": fn,
+    }
+
+
+def _binary_metrics(counts: dict[str, int]) -> dict[str, float | None]:
+    tp = counts["true_positive"]
+    fp = counts["false_positive"]
+    tn = counts["true_negative"]
+    fn = counts["false_negative"]
+    precision = tp / (tp + fp) if tp + fp else 0.0
+    recall = tp / (tp + fn) if tp + fn else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    denominator = math.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
+    mcc = ((tp * tn) - (fp * fn)) / denominator if denominator else None
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "mcc": mcc,
+    }
+
+
+def _load_calibration_predictions(
+    config: AppConfig,
+    *,
+    input_predictions: Path | None,
+    input_labeled: Path | None,
+) -> tuple[list[dict[str, Any]], str]:
+    explicit_predictions = input_predictions is not None
+    prediction_path = input_predictions or config.data.predictions_path
+    if prediction_path.exists():
+        rows = read_all_rows(prediction_path)
+        if _has_ground_truth(rows):
+            return rows, str(prediction_path)
+        if explicit_predictions:
+            raise CalibrationError(
+                f"Prediction rows in {prediction_path} must include ground_truth for calibration"
+            )
+        if not config.calibration.prepare_predictions_if_missing:
+            raise CalibrationError(
+                f"Prediction rows in {prediction_path} lack ground_truth; enable "
+                "calibration.prepare_predictions_if_missing or provide --input-labeled"
+            )
+    elif explicit_predictions:
+        raise CalibrationError(f"Prediction input not found: {prediction_path}")
+    elif not config.calibration.prepare_predictions_if_missing:
+        raise CalibrationError(
+            f"Prediction input not found: {prediction_path}; enable "
+            "calibration.prepare_predictions_if_missing or provide --input-labeled"
+        )
+
+    labeled_path = input_labeled or config.data.labeled_path
+    if not labeled_path.exists():
+        raise CalibrationError(
+            f"Labeled input not found for prediction preparation: {labeled_path}"
+        )
+    if not config.model.checkpoint_path.exists():
+        raise CalibrationError(
+            f"Model checkpoint not found for prediction preparation: {config.model.checkpoint_path}"
+        )
+    model = load_checkpoint(config.model.checkpoint_path)
+    rows = classify_rows(
+        iter_rows(labeled_path),
+        model,
+        config.features,
+        label_mode=config.labeling.mode,
+    )
+    return rows, f"generated from {labeled_path}"
+
+
+def _has_ground_truth(rows: list[dict[str, Any]]) -> bool:
+    return bool(rows) and all(row.get("ground_truth") is not None for row in rows)
+
+
+def _require_ground_truth(rows: list[dict[str, Any]]) -> None:
+    if not _has_ground_truth(rows):
+        raise CalibrationError("Calibration requires prediction rows with ground_truth labels")
+
+
+def _target_probability(row: dict[str, Any], target_class: str) -> float:
+    raw = row.get("probabilities_json")
+    if raw:
+        try:
+            probabilities = json.loads(str(raw))
+            if target_class in probabilities:
+                return float(probabilities[target_class])
+        except Exception:
+            pass
+    if str(row.get("predicted_class")) == target_class:
+        return float(row.get("confidence") or 1.0)
+    return 0.0
+
+
+def _validate_objective(value: str) -> str:
+    if value not in OBJECTIVES:
+        raise CalibrationError(f"objective must be one of {', '.join(sorted(OBJECTIVES))}")
+    return value
+
+
+def _with_current_value(values: Iterable[float], current: float) -> list[float]:
+    return sorted({round(float(value), 10) for value in [*values, current]})
+
+
+def _score(value: Any) -> float:
+    return float(value) if isinstance(value, int | float) else -1.0
+
+
+def _metric_fields() -> list[str]:
+    return [
+        "window_count",
+        "support",
+        "positive_support",
+        "truth_absent_windows",
+        "true_positive",
+        "false_positive",
+        "true_negative",
+        "false_negative",
+        "precision",
+        "recall",
+        "f1",
+        "mcc",
+        "objective_score",
+    ]
+
+
+def _flatten_artifact_paths(artifacts: dict[str, Path | dict[str, Path]]) -> list[Path]:
+    paths: list[Path] = []
+    for value in artifacts.values():
+        if isinstance(value, dict):
+            paths.extend(value.values())
+        else:
+            paths.append(value)
+    return paths
+
+
+def _remove_outputs(paths: Iterable[Path]) -> None:
+    for path in paths:
+        if path.exists():
+            path.unlink()
+
+
+def _manifest_artifacts(
+    artifacts: dict[str, Path | dict[str, Path]],
+    chart_paths: dict[str, Path],
+) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for name, value in artifacts.items():
+        if name == "charts":
+            output[name] = {metric: str(path) for metric, path in chart_paths.items()}
+        elif isinstance(value, dict):
+            output[name] = {nested: str(path) for nested, path in value.items()}
+        else:
+            output[name] = str(value)
+    return output
+
+
+def _new_manifest(
+    *,
+    config: AppConfig,
+    config_path: Path,
+    output_dir: Path,
+    objective: str,
+    target_classes: list[str],
+) -> dict[str, Any]:
+    return {
+        "status": "running",
+        "created_at": _now(),
+        "ended_at": None,
+        "config_path": str(config_path),
+        "output_dir": str(output_dir),
+        "package_version": __version__,
+        "random_seed": config.random_seed,
+        "objective": objective,
+        "target_classes": target_classes,
+        "window_types": list(config.calibration.window_types),
+        "min_truth_frames": config.calibration.min_truth_frames,
+        "feature_names": model_feature_names(config.features),
+        "leakage_debug": config.features.leakage_debug,
+        "label_mode": config.labeling.mode,
+        "windowing": {
+            "frame_count": config.windowing.frame_count,
+            "time_seconds": config.windowing.time_seconds,
+            "min_frames": config.windowing.min_frames,
+            "present_ratio_threshold": config.windowing.present_ratio_threshold,
+            "mean_probability_threshold": config.windowing.mean_probability_threshold,
+            "max_probability_threshold": config.windowing.max_probability_threshold,
+        },
+    }
+
+
+def _write_results_csv(path: Path, results: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=RESULT_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(results)
+
+
+def _looks_synthetic(config: AppConfig, predictions: list[dict[str, Any]]) -> bool:
+    text_parts = [
+        str(config.output_dir),
+        *(str(path) for path in config.input.paths),
+        *(str(row.get("source_file") or "") for row in predictions[:20]),
+    ]
+    return any("synthetic" in value.lower() for value in text_parts)
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()

--- a/src/peekaboo/cli.py
+++ b/src/peekaboo/cli.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
+from peekaboo.calibration import CalibrationError, run_presence_calibration
 from peekaboo.capture.inspect import inspect_capture_paths, write_inspection_markdown
 from peekaboo.capture.live import iter_live_records
 from peekaboo.capture.sources import expand_input_paths, iter_packet_records
@@ -123,6 +124,47 @@ def compare_command(
         raise typer.Exit(1) from exc
     typer.echo(
         f"Comparison {manifest['status']} with {manifest['result_count']} result row(s). "
+        f"Wrote {manifest['artifacts']['manifest']}"
+    )
+
+
+@app.command("calibrate-presence")
+def calibrate_presence(
+    config: ConfigOption,
+    input_predictions: Annotated[Path | None, typer.Option("--input-predictions")] = None,
+    input_labeled: Annotated[Path | None, typer.Option("--input-labeled")] = None,
+    output_dir: Annotated[Path | None, typer.Option("--output-dir")] = None,
+    target_class: Annotated[
+        list[str] | None,
+        typer.Option("--target-class", help="Target class to calibrate; repeat for many."),
+    ] = None,
+    all_targets: Annotated[
+        bool | None,
+        typer.Option("--all-targets/--single-target", help="Calibrate all enabled targets."),
+    ] = None,
+    objective: Annotated[str | None, typer.Option("--objective")] = None,
+    force: Annotated[bool, typer.Option("--force")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+) -> None:
+    try:
+        manifest = run_presence_calibration(
+            config,
+            input_predictions=input_predictions,
+            input_labeled=input_labeled,
+            output_dir=output_dir,
+            target_classes=target_class,
+            all_targets=all_targets,
+            objective=objective,
+            force=force,
+            quiet=quiet,
+            progress=typer.echo,
+        )
+    except CalibrationError as exc:
+        typer.secho(str(exc), err=True)
+        raise typer.Exit(1) from exc
+
+    typer.echo(
+        f"Calibration {manifest['status']} with {manifest['result_count']} result row(s). "
         f"Wrote {manifest['artifacts']['manifest']}"
     )
 

--- a/src/peekaboo/config.py
+++ b/src/peekaboo/config.py
@@ -90,6 +90,63 @@ class PresenceConfig(BaseModel):
     all_targets: bool = False
 
 
+class CalibrationConfig(BaseModel):
+    objective: str = "f1"
+    present_ratio_thresholds: list[float] = Field(
+        default_factory=lambda: [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    )
+    mean_probability_thresholds: list[float] = Field(
+        default_factory=lambda: [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    )
+    max_probability_thresholds: list[float] = Field(
+        default_factory=lambda: [0.5, 0.6, 0.7, 0.8, 0.9]
+    )
+    window_types: list[str] = Field(default_factory=lambda: ["frame_count", "time"])
+    min_truth_frames: int = 1
+    prepare_predictions_if_missing: bool = True
+    output_dir: Path | None = None
+
+    @field_validator("objective")
+    @classmethod
+    def validate_objective(cls, value: str) -> str:
+        allowed = {"f1", "mcc", "precision", "recall"}
+        if value not in allowed:
+            raise ValueError(f"calibration.objective must be one of {', '.join(sorted(allowed))}")
+        return value
+
+    @field_validator(
+        "present_ratio_thresholds",
+        "mean_probability_thresholds",
+        "max_probability_thresholds",
+    )
+    @classmethod
+    def validate_thresholds(cls, value: list[float]) -> list[float]:
+        if not value:
+            raise ValueError("calibration threshold grids must not be empty")
+        invalid = [threshold for threshold in value if threshold < 0 or threshold > 1]
+        if invalid:
+            raise ValueError("calibration threshold values must satisfy 0 <= threshold <= 1")
+        return sorted(set(value))
+
+    @field_validator("window_types")
+    @classmethod
+    def validate_window_types(cls, value: list[str]) -> list[str]:
+        allowed = {"frame_count", "time"}
+        if not value:
+            raise ValueError("calibration.window_types must include at least one window type")
+        unknown = sorted(set(value) - allowed)
+        if unknown:
+            raise ValueError(f"Unsupported calibration window type(s): {', '.join(unknown)}")
+        return list(dict.fromkeys(value))
+
+    @field_validator("min_truth_frames")
+    @classmethod
+    def validate_min_truth_frames(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("calibration.min_truth_frames must be greater than 0")
+        return value
+
+
 class ComparisonConfig(BaseModel):
     models: list[str] = Field(default_factory=lambda: list(MODEL_MAPPINGS))
     train_fractions: list[float] = Field(default_factory=lambda: [0.01, 0.1, 0.5, 0.9])
@@ -131,10 +188,13 @@ class AppConfig(BaseModel):
     split: SplitConfig = Field(default_factory=SplitConfig)
     windowing: WindowConfig = Field(default_factory=WindowConfig)
     presence: PresenceConfig = Field(default_factory=PresenceConfig)
+    calibration: CalibrationConfig = Field(default_factory=CalibrationConfig)
     comparison: ComparisonConfig = Field(default_factory=ComparisonConfig)
 
     @model_validator(mode="after")
-    def default_comparison_output_dir(self) -> AppConfig:
+    def default_derived_output_dirs(self) -> AppConfig:
+        if self.calibration.output_dir is None:
+            self.calibration.output_dir = self.output_dir / "calibration"
         if self.comparison.output_dir is None:
             self.comparison.output_dir = self.output_dir / "comparison"
         return self

--- a/src/peekaboo/inference/aggregate.py
+++ b/src/peekaboo/inference/aggregate.py
@@ -107,7 +107,9 @@ def summarize_presence_window(
     positive_ratio = len(positives) / len(rows) if rows else None
     mean_probability = mean(probabilities) if probabilities else None
     max_probability = max(probabilities) if probabilities else None
-    state = _presence_state(len(rows), positive_ratio, mean_probability, max_probability, config)
+    state = presence_state_from_stats(
+        len(rows), positive_ratio, mean_probability, max_probability, config
+    )
     return RollingPresenceRow(
         window_start=window_start,
         window_end=window_end,
@@ -118,6 +120,22 @@ def summarize_presence_window(
         positive_prediction_ratio=positive_ratio,
         state=state,
     ).to_dict()
+
+
+def presence_state_from_stats(
+    frame_count: int,
+    positive_ratio: float | None,
+    mean_probability: float | None,
+    max_probability: float | None,
+    config: WindowConfig,
+) -> str:
+    return _presence_state(
+        frame_count,
+        positive_ratio,
+        mean_probability,
+        max_probability,
+        config,
+    )
 
 
 def _target_probability(row: dict[str, Any], target_class: str) -> float:

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,300 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from peekaboo.calibration import (
+    calibration_window_stats,
+    evaluate_calibration_candidates,
+    recommend_thresholds,
+    threshold_candidates,
+    write_calibration_report,
+    write_recommended_windowing,
+)
+from peekaboo.capture.synthetic import IPHONE_MAC, LG_TV_MAC, write_synthetic_capture
+from peekaboo.cli import app
+from peekaboo.config import AppConfig, CalibrationConfig, WindowConfig
+from peekaboo.data.readers import read_all_rows, read_json
+
+
+def prediction(
+    timestamp: float,
+    *,
+    predicted_class: str,
+    ground_truth: str,
+    target_probability: float,
+) -> dict[str, object]:
+    return {
+        "timestamp": timestamp,
+        "packet_index": int(timestamp),
+        "predicted_class": predicted_class,
+        "confidence": target_probability,
+        "ground_truth": ground_truth,
+        "probabilities_json": json.dumps(
+            {"target": target_probability, "other": 1 - target_probability}
+        ),
+    }
+
+
+def test_calibration_config_defaults_and_validation():
+    config = AppConfig(output_dir=Path("runs/test"))
+
+    assert config.calibration.output_dir == Path("runs/test/calibration")
+    assert config.calibration.objective == "f1"
+
+    with pytest.raises(ValueError, match="objective"):
+        CalibrationConfig(objective="accuracy")
+    with pytest.raises(ValueError, match="threshold"):
+        CalibrationConfig(present_ratio_thresholds=[-0.1])
+    with pytest.raises(ValueError, match="window type"):
+        CalibrationConfig(window_types=["session"])
+    with pytest.raises(ValueError, match="min_truth_frames"):
+        CalibrationConfig(min_truth_frames=0)
+
+
+def test_window_truth_labeling_threshold_sweep_and_recommendation(tmp_path: Path):
+    rows = [
+        prediction(0, predicted_class="target", ground_truth="target", target_probability=0.9),
+        prediction(1, predicted_class="target", ground_truth="target", target_probability=0.8),
+        prediction(2, predicted_class="other", ground_truth="other", target_probability=0.1),
+        prediction(3, predicted_class="other", ground_truth="other", target_probability=0.2),
+    ]
+    window_config = WindowConfig(
+        frame_count=2,
+        time_seconds=10,
+        min_frames=1,
+        present_ratio_threshold=0.5,
+        mean_probability_threshold=0.5,
+        max_probability_threshold=0.8,
+    )
+    calibration_config = CalibrationConfig(
+        present_ratio_thresholds=[0.5],
+        mean_probability_thresholds=[0.5],
+        max_probability_thresholds=[0.8],
+        window_types=["frame_count"],
+    )
+
+    windows = calibration_window_stats(
+        rows,
+        target_classes=["target"],
+        window_config=window_config,
+        window_types=["frame_count"],
+        min_truth_frames=1,
+    )
+    candidates = threshold_candidates(window_config, calibration_config)
+    results = evaluate_calibration_candidates(
+        windows,
+        candidates=candidates,
+        base_window_config=window_config,
+        objective="f1",
+    )
+    recommendation = recommend_thresholds(results, objective="f1")
+
+    assert [window["truth_present"] for window in windows] == [True, False]
+    assert len(candidates) == 1
+    assert recommendation["metrics"]["true_positive"] == 1
+    assert recommendation["metrics"]["true_negative"] == 1
+    assert recommendation["metrics"]["f1"] == 1.0
+
+    report_path = tmp_path / "calibration_report.md"
+    yaml_path = tmp_path / "recommended_windowing.yaml"
+    manifest = {
+        "status": "completed",
+        "config_path": "config.yaml",
+        "objective": "f1",
+        "target_classes": ["target"],
+        "prediction_source": "unit",
+        "prediction_rows": len(rows),
+        "window_count": len(windows),
+        "warnings": [],
+        "recommendation": recommendation,
+        "artifacts": {"recommended_windowing": str(yaml_path)},
+    }
+    write_calibration_report(report_path, manifest=manifest, results=results)
+    write_recommended_windowing(yaml_path, base=window_config, recommendation=recommendation)
+
+    assert "peekaboo Presence Calibration" in report_path.read_text(encoding="utf-8")
+    recommended = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    assert recommended["windowing"]["present_ratio_threshold"] == 0.5
+
+
+def test_calibrate_presence_cli_regenerates_labeled_predictions(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_config(config_path, targets_path, capture_path, output_dir)
+
+    runner = CliRunner()
+    run_result = runner.invoke(
+        app,
+        ["run", "--config", str(config_path), "--force", "--quiet"],
+    )
+    assert run_result.exit_code == 0, run_result.output
+    saved_predictions = read_all_rows(output_dir / "predictions.parquet")
+    assert all(row.get("ground_truth") is None for row in saved_predictions)
+
+    result = runner.invoke(
+        app,
+        ["calibrate-presence", "--config", str(config_path), "--force", "--quiet"],
+    )
+
+    assert result.exit_code == 0, result.output
+    calibration_dir = output_dir / "calibration"
+    manifest = read_json(calibration_dir / "calibration_manifest.json")
+    rows = read_all_rows(calibration_dir / "calibration_results.csv")
+    assert manifest["status"] == "completed"
+    assert manifest["prediction_source"].startswith("generated from")
+    assert "source_mac" not in manifest["feature_names"]
+    assert "destination_mac" not in manifest["feature_names"]
+    assert rows
+    assert (calibration_dir / "calibration_results.json").exists()
+    assert (calibration_dir / "calibration_report.md").exists()
+    assert (calibration_dir / "recommended_windowing.yaml").exists()
+    assert any((calibration_dir / f"calibration_{metric}.png").exists() for metric in ["f1", "mcc"])
+
+
+def test_calibrate_presence_cli_all_targets_and_missing_ground_truth_failure(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+    config_path = tmp_path / "config.yaml"
+    targets_path = tmp_path / "targets.yaml"
+    output_dir = tmp_path / "runs"
+    write_synthetic_capture(capture_path)
+    _write_config(config_path, targets_path, capture_path, output_dir, multiclass=True)
+
+    runner = CliRunner()
+    for command in ["ingest", "features", "label", "train-online"]:
+        result = runner.invoke(app, [command, "--config", str(config_path)])
+        assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        app,
+        ["calibrate-presence", "--config", str(config_path), "--all-targets", "--quiet"],
+    )
+
+    assert result.exit_code == 0, result.output
+    rows = read_all_rows(output_dir / "calibration" / "calibration_results.csv")
+    assert {"iphone_5_user1", "lg_tv"} <= {
+        row["target_id"] for row in rows if row["scope"] == "target_window"
+    }
+
+    unlabeled_path = output_dir / "unlabeled_predictions.jsonl"
+    unlabeled_path.write_text(
+        json.dumps(
+            {
+                "timestamp": 0,
+                "predicted_class": "target",
+                "confidence": 1.0,
+                "probabilities_json": json.dumps({"target": 1.0, "other": 0.0}),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    failure = runner.invoke(
+        app,
+        [
+            "calibrate-presence",
+            "--config",
+            str(config_path),
+            "--input-predictions",
+            str(unlabeled_path),
+            "--output-dir",
+            str(output_dir / "explicit-unlabeled"),
+        ],
+    )
+
+    assert failure.exit_code == 1
+    assert "ground_truth" in failure.output
+
+
+def _write_config(
+    config_path: Path,
+    targets_path: Path,
+    capture_path: Path,
+    output_dir: Path,
+    *,
+    multiclass: bool = False,
+) -> None:
+    targets_path.write_text(
+        yaml.safe_dump(
+            {
+                "targets": [
+                    {
+                        "target_id": "iphone_5_user1",
+                        "label": "phone",
+                        "mac_addresses": [IPHONE_MAC],
+                        "enabled": True,
+                    },
+                    {
+                        "target_id": "lg_tv",
+                        "label": "tv",
+                        "mac_addresses": [LG_TV_MAC],
+                        "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input": {"paths": [str(capture_path)], "live_interface": None},
+                "target_registry_path": str(targets_path),
+                "output_dir": str(output_dir),
+                "random_seed": 42,
+                "features": {
+                    "data_size_mode": "dot11_frame_len",
+                    "leakage_debug": False,
+                    "impute_numeric": -1.0,
+                    "impute_categorical": "missing",
+                },
+                "labeling": {
+                    "mode": "multiclass_with_other" if multiclass else "binary_one_vs_rest",
+                    "target_id": None if multiclass else "iphone_5_user1",
+                    "positive_label": "target",
+                    "negative_label": "other",
+                },
+                "presence": {"target_classes": [], "all_targets": multiclass},
+                "data": {
+                    "normalized_path": str(output_dir / "records.parquet"),
+                    "features_path": str(output_dir / "features.parquet"),
+                    "labeled_path": str(output_dir / "labeled.parquet"),
+                    "train_path": str(output_dir / "train.parquet"),
+                    "test_path": str(output_dir / "test.parquet"),
+                    "predictions_path": str(output_dir / "predictions.parquet"),
+                    "rolling_path": str(output_dir / "rolling.parquet"),
+                    "metrics_path": str(output_dir / "metrics.json"),
+                },
+                "model": {
+                    "model_id": "leveraging_bag",
+                    "checkpoint_path": str(output_dir / "model.pkl"),
+                    "params": {"n_models": 5, "base_model": {"grace_period": 5}},
+                },
+                "split": {"train_fraction": 0.75, "chronological": True},
+                "windowing": {
+                    "frame_count": 20,
+                    "time_seconds": 20,
+                    "min_frames": 5,
+                    "present_ratio_threshold": 0.3,
+                    "mean_probability_threshold": 0.3,
+                    "max_probability_threshold": 0.8,
+                },
+                "calibration": {
+                    "objective": "f1",
+                    "present_ratio_thresholds": [0.2, 0.3, 0.4],
+                    "mean_probability_thresholds": [0.2, 0.3, 0.4],
+                    "max_probability_thresholds": [0.7, 0.8],
+                    "window_types": ["frame_count", "time"],
+                    "min_truth_frames": 1,
+                    "prepare_predictions_if_missing": True,
+                    "output_dir": str(output_dir / "calibration"),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ def test_cli_help_smoke():
     assert result.exit_code == 0
     assert "run" in result.output
     assert "compare" in result.output
+    assert "calibrate-presence" in result.output
     assert "setup" in result.output
     assert "inspect" in result.output
     assert "ingest" in result.output


### PR DESCRIPTION
## Summary
- Adds `peekaboo calibrate-presence` for sweeping presence thresholds over labeled predictions or regenerated labeled checkpoint predictions.
- Adds calibration config defaults, validation, reports, JSON/CSV outputs, recommended windowing YAML, and best-effort charts.
- Documents the synthetic calibration workflow and adds binary plus multi-target calibration tests.

Closes #27

## Validation
- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m compileall -q src tests`
- Manual: `.venv/bin/python examples/generate_synthetic_capture.py && .venv/bin/peekaboo run --config configs/synthetic-demo.yaml --force --quiet && .venv/bin/peekaboo calibrate-presence --config configs/synthetic-demo.yaml --force --quiet && .venv/bin/peekaboo run --config configs/synthetic-multitarget.yaml --force --quiet && .venv/bin/peekaboo calibrate-presence --config configs/synthetic-multitarget.yaml --all-targets --force --quiet`

## Safety
Calibration operates on existing metadata-only predictions/labeled rows. It does not decrypt traffic, inspect payloads, inject frames, probe networks, configure adapters, or channel hop.