### PR TITLE
[codex] Add richer synthetic demo capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ peekaboo setup \
 
 ## Try It With Synthetic Data
 
-The repository includes a generator for a deterministic synthetic Radiotap/802.11 capture. It contains fake MAC addresses and fake frame metadata, so it is safe to use as a first-run demo. The synthetic traffic is intentionally learnable from allowed header-level features such as rate, signal, subtype, and frame size; it is not real-world performance evidence.
+The repository includes a generator for a deterministic synthetic Radiotap/802.11 capture. It contains fake MAC addresses and fake frame metadata, so it is safe to use as a first-run demo. The default 120-frame story includes a phone arriving, quiet background chatter, a phone browsing burst, TV streaming, weak edge-of-house traffic, retries, channel changes, RSSI drift, and multiple fake destinations. The synthetic traffic is intentionally learnable from allowed header-level features such as rate, signal, subtype, and frame size; it is not real-world performance evidence.
 
 ```bash
 python examples/generate_synthetic_capture.py

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-Generate a deterministic synthetic Radiotap/802.11 capture and run the full demo pipeline:
+Generate a richer deterministic synthetic Radiotap/802.11 capture and run the full demo pipeline:
 
 ```bash
 python examples/generate_synthetic_capture.py
@@ -13,7 +13,7 @@ peekaboo calibrate-presence --config configs/synthetic-multitarget.yaml --all-ta
 peekaboo presence-replay --config configs/synthetic-multitarget.yaml --all-targets
 ```
 
-The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, `run_manifest.json`, `run_summary.md`, Markdown report, static HTML dashboard, calibration outputs, and aggregate comparison outputs under `runs/synthetic-demo/`, which is also ignored by Git. Synthetic calibration and comparison results are onboarding smoke evidence only, not real-world wireless performance evidence.
+The generated capture is written to `examples/captures/synthetic-demo.pcap`, which is ignored by Git. Its default 120-frame fake traffic story includes a phone arriving, quiet background chatter, a phone browsing burst, TV streaming, weak edge-of-house traffic, retries, channel changes, RSSI drift, and multiple fake destinations. The demo writes its Parquet datasets, model checkpoint, metrics, rolling summaries, live-style replay JSONL streams, `run_manifest.json`, `run_summary.md`, Markdown report, static HTML dashboard, calibration outputs, and aggregate comparison outputs under `runs/synthetic-demo/`, which is also ignored by Git. Synthetic calibration and comparison results are onboarding smoke evidence only, not real-world wireless performance evidence.
 
 The multi-target demo writes separate multiclass outputs under `runs/synthetic-multitarget/` and emits presence rows for each enabled known target in `configs/targets.yaml`.
 

--- a/examples/generate_synthetic_capture.py
+++ b/examples/generate_synthetic_capture.py
@@ -1,4 +1,4 @@
-"""Generate the synthetic capture used by the example config."""
+"""Generate the richer deterministic synthetic capture used by the example configs."""
 
 from __future__ import annotations
 
@@ -24,7 +24,10 @@ def main() -> None:
         "--packet-count",
         type=int,
         default=120,
-        help="Number of synthetic packets to generate.",
+        help=(
+            "Number of synthetic packets to generate. The first 120 packets form one "
+            "complete fake traffic story; larger values repeat it with later timestamps."
+        ),
     )
     args = parser.parse_args()
     output = write_synthetic_capture(args.output, packet_count=args.packet_count)

--- a/src/peekaboo/capture/synthetic.py
+++ b/src/peekaboo/capture/synthetic.py
@@ -2,17 +2,66 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 AP_MAC = "66:55:44:33:22:11"
 IPHONE_MAC = "aa:bb:cc:dd:ee:ff"
 LG_TV_MAC = "11:22:33:44:55:66"
 UNKNOWN_MAC = "22:33:44:55:66:77"
+SMART_SPEAKER_MAC = "02:33:44:55:66:88"
 INTERNET_MAC = "ff:ff:ff:ff:ff:ff"
+PHONE_SERVICE_MAC = "02:00:00:00:10:01"
+TV_SERVICE_MAC = "02:00:00:00:20:01"
+IOT_SERVICE_MAC = "02:00:00:00:30:01"
+MULTICAST_MAC = "01:00:5e:00:00:fb"
+
+_BASE_TIMESTAMP = 1_700_000_000
+_STORY_PACKET_COUNT = 120
+_CYCLE_SECONDS = 7_200
+_CHANNEL_FLAGS = 0x00A0
+_PROTECTED_TO_DS = 0x41
+_RETRY = 0x08
+
+
+@dataclass(frozen=True)
+class _SyntheticScene:
+    name: str
+    start: int
+    stop: int
+    timestamp_offset: int
+
+
+@dataclass(frozen=True)
+class _SyntheticPacketSpec:
+    source_mac: str
+    destination_mac: str
+    rssi: int
+    rate: int
+    subtype: int
+    payload_len: int
+    channel_frequency: int
+    timestamp: float
+    retry: bool = False
+
+
+_SCENES = (
+    _SyntheticScene("phone_arrival", 0, 18, 0),
+    _SyntheticScene("quiet_house", 18, 36, 240),
+    _SyntheticScene("phone_browse_burst", 36, 64, 900),
+    _SyntheticScene("tv_streaming", 64, 84, 1_800),
+    _SyntheticScene("edge_of_house", 84, 100, 3_600),
+    _SyntheticScene("evening_return", 100, 120, 5_400),
+)
 
 
 def write_synthetic_capture(path: str | Path, *, packet_count: int = 120) -> Path:
-    """Write a deterministic passive-safe Radiotap/Dot11 PCAP fixture."""
+    """Write a deterministic passive-safe Radiotap/Dot11 PCAP fixture.
+
+    The first 120 packets form one complete fake household traffic story. Larger
+    captures repeat that story with increasing timestamps so tests and examples
+    can scale without changing the shape of the demo.
+    """
     try:
         from scapy.layers.dot11 import Dot11, RadioTap  # type: ignore
         from scapy.packet import Raw  # type: ignore
@@ -24,57 +73,282 @@ def write_synthetic_capture(path: str | Path, *, packet_count: int = 120) -> Pat
     output.parent.mkdir(parents=True, exist_ok=True)
     packets = []
     for index in range(packet_count):
-        source_mac, destination_mac, rssi, rate, subtype, payload_len = _packet_spec(index)
+        spec = _packet_spec(index)
+        fcfield = _PROTECTED_TO_DS | (_RETRY if spec.retry else 0)
         packet = (
             RadioTap(
                 present="Rate+Channel+dBm_AntSignal",
-                Rate=rate,
-                ChannelFrequency=2412,
-                ChannelFlags=0x00A0,
-                dBm_AntSignal=rssi,
+                Rate=spec.rate,
+                ChannelFrequency=spec.channel_frequency,
+                ChannelFlags=_CHANNEL_FLAGS,
+                dBm_AntSignal=spec.rssi,
             )
             / Dot11(
                 type=2,
-                subtype=subtype,
-                FCfield=0x41,
+                subtype=spec.subtype,
+                FCfield=fcfield,
                 addr1=AP_MAC,
-                addr2=source_mac,
-                addr3=destination_mac,
+                addr2=spec.source_mac,
+                addr3=spec.destination_mac,
                 SC=index << 4,
             )
-            / Raw(bytes([index + 1]) * payload_len)
+            / Raw(bytes([_payload_byte(index)]) * spec.payload_len)
         )
-        packet.time = 1_700_000_000 + index
+        packet.time = spec.timestamp
         packets.append(packet)
 
     wrpcap(str(output), packets)
     return output
 
 
-def _packet_spec(index: int) -> tuple[str, str, int, int, int, int]:
-    if index % 3 == 0:
-        return (
-            IPHONE_MAC,
-            INTERNET_MAC,
-            -38 - (index % 5),
-            54 if index % 2 else 48,
-            0,
-            72 + (index % 4) * 4,
+def _packet_spec(index: int) -> _SyntheticPacketSpec:
+    scene, local_index, cycle = _scene_for_index(index)
+    timestamp = _timestamp(scene, local_index, cycle)
+
+    if scene.name == "phone_arrival":
+        if local_index % 4 in {0, 1}:
+            return _iphone_frame(
+                timestamp,
+                rssi=-72 + min(local_index * 2, 34),
+                rate=24 if local_index < 5 else (48 if local_index % 2 else 54),
+                subtype=8 if local_index % 3 else 0,
+                payload_len=68 + (local_index % 5) * 12,
+                channel_frequency=2412,
+                retry=local_index < 4,
+            )
+        if local_index % 4 == 2:
+            return _tv_frame(
+                timestamp,
+                rssi=-62 - (local_index % 3),
+                rate=18,
+                subtype=4,
+                payload_len=28 + (local_index % 2) * 8,
+                channel_frequency=2412,
+            )
+        return _background_frame(
+            timestamp,
+            source_mac=UNKNOWN_MAC,
+            rssi=-78 - (local_index % 4),
+            rate=6,
+            subtype=8,
+            payload_len=34 + (local_index % 3) * 4,
+            channel_frequency=2412,
         )
-    if index % 3 == 1:
-        return (
-            LG_TV_MAC,
-            INTERNET_MAC,
-            -63 - (index % 4),
-            12 if index % 2 else 18,
-            4,
-            24 + (index % 3) * 3,
+
+    if scene.name == "quiet_house":
+        if local_index % 6 == 0:
+            return _iphone_frame(
+                timestamp,
+                rssi=-50 - (local_index % 5),
+                rate=36,
+                subtype=4,
+                payload_len=24,
+                channel_frequency=2437,
+            )
+        if local_index % 3 == 0:
+            return _tv_frame(
+                timestamp,
+                rssi=-64 - (local_index % 4),
+                rate=12,
+                subtype=4,
+                payload_len=26,
+                channel_frequency=2437,
+            )
+        return _background_frame(
+            timestamp,
+            source_mac=SMART_SPEAKER_MAC if local_index % 2 else UNKNOWN_MAC,
+            rssi=-69 - (local_index % 7),
+            rate=9 if local_index % 2 else 6,
+            subtype=0,
+            payload_len=30 + (local_index % 4) * 5,
+            channel_frequency=2437,
+            destination_mac=MULTICAST_MAC if local_index % 5 == 0 else IOT_SERVICE_MAC,
         )
-    return (
-        UNKNOWN_MAC,
-        INTERNET_MAC,
-        -72 - (index % 6),
-        6 if index % 2 else 9,
-        8,
-        36 + (index % 5) * 2,
+
+    if scene.name == "phone_browse_burst":
+        if local_index % 5 in {0, 1, 2, 3}:
+            return _iphone_frame(
+                timestamp,
+                rssi=-39 - (local_index % 6),
+                rate=54 if local_index % 3 else 48,
+                subtype=8,
+                payload_len=118 + (local_index % 7) * 18,
+                channel_frequency=2412 if local_index < 18 else 2437,
+                retry=local_index in {9, 10, 21},
+            )
+        return _background_frame(
+            timestamp,
+            source_mac=UNKNOWN_MAC,
+            rssi=-74 - (local_index % 5),
+            rate=12,
+            subtype=0,
+            payload_len=44 + (local_index % 4) * 7,
+            channel_frequency=2412,
+        )
+
+    if scene.name == "tv_streaming":
+        if local_index % 5 in {0, 1, 2, 3}:
+            return _tv_frame(
+                timestamp,
+                rssi=-58 - (local_index % 7),
+                rate=18 if local_index % 2 else 24,
+                subtype=8,
+                payload_len=150 + (local_index % 6) * 22,
+                channel_frequency=2462,
+                retry=local_index in {6, 7, 13},
+            )
+        return _iphone_frame(
+            timestamp,
+            rssi=-48 - (local_index % 3),
+            rate=36,
+            subtype=4,
+            payload_len=28 + (local_index % 3) * 6,
+            channel_frequency=2462,
+        )
+
+    if scene.name == "edge_of_house":
+        if local_index % 2 == 0:
+            return _iphone_frame(
+                timestamp,
+                rssi=-76 - (local_index % 8),
+                rate=12 if local_index % 4 else 9,
+                subtype=0 if local_index % 3 else 8,
+                payload_len=54 + (local_index % 5) * 8,
+                channel_frequency=2462,
+                retry=True,
+            )
+        return _background_frame(
+            timestamp,
+            source_mac=UNKNOWN_MAC,
+            rssi=-82 - (local_index % 5),
+            rate=6,
+            subtype=8,
+            payload_len=38 + (local_index % 4) * 6,
+            channel_frequency=2462,
+            retry=local_index % 3 == 1,
+        )
+
+    if local_index % 5 in {0, 1}:
+        return _iphone_frame(
+            timestamp,
+            rssi=-44 - (local_index % 5),
+            rate=54,
+            subtype=8,
+            payload_len=96 + (local_index % 6) * 20,
+            channel_frequency=2437 if local_index < 10 else 2412,
+        )
+    if local_index % 5 in {2, 3}:
+        return _tv_frame(
+            timestamp,
+            rssi=-61 - (local_index % 4),
+            rate=18,
+            subtype=8 if local_index % 2 else 0,
+            payload_len=104 + (local_index % 5) * 16,
+            channel_frequency=2437,
+        )
+    return _background_frame(
+        timestamp,
+        source_mac=SMART_SPEAKER_MAC,
+        rssi=-70 - (local_index % 6),
+        rate=9,
+        subtype=0,
+        payload_len=42 + (local_index % 3) * 10,
+        channel_frequency=2437,
+        destination_mac=IOT_SERVICE_MAC,
     )
+
+
+def _scene_for_index(index: int) -> tuple[_SyntheticScene, int, int]:
+    story_index = index % _STORY_PACKET_COUNT
+    cycle = index // _STORY_PACKET_COUNT
+    for scene in _SCENES:
+        if scene.start <= story_index < scene.stop:
+            return scene, story_index - scene.start, cycle
+    last_scene = _SCENES[-1]
+    return last_scene, last_scene.stop - last_scene.start - 1, cycle
+
+
+def _timestamp(scene: _SyntheticScene, local_index: int, cycle: int) -> float:
+    burst_jitter = 0.35 if local_index % 4 == 0 else 0.0
+    return (
+        _BASE_TIMESTAMP
+        + (cycle * _CYCLE_SECONDS)
+        + scene.timestamp_offset
+        + local_index * 2.0
+        + burst_jitter
+    )
+
+
+def _iphone_frame(
+    timestamp: float,
+    *,
+    rssi: int,
+    rate: int,
+    subtype: int,
+    payload_len: int,
+    channel_frequency: int,
+    retry: bool = False,
+) -> _SyntheticPacketSpec:
+    return _SyntheticPacketSpec(
+        source_mac=IPHONE_MAC,
+        destination_mac=PHONE_SERVICE_MAC,
+        rssi=rssi,
+        rate=rate,
+        subtype=subtype,
+        payload_len=payload_len,
+        channel_frequency=channel_frequency,
+        timestamp=timestamp,
+        retry=retry,
+    )
+
+
+def _tv_frame(
+    timestamp: float,
+    *,
+    rssi: int,
+    rate: int,
+    subtype: int,
+    payload_len: int,
+    channel_frequency: int,
+    retry: bool = False,
+) -> _SyntheticPacketSpec:
+    return _SyntheticPacketSpec(
+        source_mac=LG_TV_MAC,
+        destination_mac=TV_SERVICE_MAC,
+        rssi=rssi,
+        rate=rate,
+        subtype=subtype,
+        payload_len=payload_len,
+        channel_frequency=channel_frequency,
+        timestamp=timestamp,
+        retry=retry,
+    )
+
+
+def _background_frame(
+    timestamp: float,
+    *,
+    source_mac: str,
+    rssi: int,
+    rate: int,
+    subtype: int,
+    payload_len: int,
+    channel_frequency: int,
+    destination_mac: str = INTERNET_MAC,
+    retry: bool = False,
+) -> _SyntheticPacketSpec:
+    return _SyntheticPacketSpec(
+        source_mac=source_mac,
+        destination_mac=destination_mac,
+        rssi=rssi,
+        rate=rate,
+        subtype=subtype,
+        payload_len=payload_len,
+        channel_frequency=channel_frequency,
+        timestamp=timestamp,
+        retry=retry,
+    )
+
+
+def _payload_byte(index: int) -> int:
+    return (index % 251) + 1

--- a/tests/test_synthetic_capture.py
+++ b/tests/test_synthetic_capture.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import pytest
+
+from peekaboo.capture.sources import iter_packet_records
+from peekaboo.capture.synthetic import (
+    IPHONE_MAC,
+    LG_TV_MAC,
+    SMART_SPEAKER_MAC,
+    UNKNOWN_MAC,
+    write_synthetic_capture,
+)
+
+pytest.importorskip("scapy")
+
+
+def test_synthetic_capture_has_rich_metadata_variation(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-demo.pcap"
+
+    write_synthetic_capture(capture_path)
+    rows = [record.to_dict() for record in iter_packet_records([capture_path])]
+
+    assert len(rows) == 120
+    assert {row["source_mac"] for row in rows} == {
+        IPHONE_MAC,
+        LG_TV_MAC,
+        SMART_SPEAKER_MAC,
+        UNKNOWN_MAC,
+    }
+    assert len({row["destination_mac"] for row in rows}) >= 5
+    assert {row["channel_frequency"] for row in rows} == {2412, 2437, 2462}
+    assert len({row["data_rate"] for row in rows}) >= 8
+    assert {row["frame_subtype"] for row in rows} == {0, 4, 8}
+    assert len({row["hour"] for row in rows}) >= 2
+    assert all(row["protected"] for row in rows)
+    assert any(row["retry"] for row in rows)
+
+    rssi_values = [float(row["rssi"]) for row in rows if row["rssi"] is not None]
+    dot11_lengths = [
+        int(row["dot11_frame_len"]) for row in rows if row["dot11_frame_len"] is not None
+    ]
+    assert max(rssi_values) - min(rssi_values) >= 40
+    assert max(dot11_lengths) - min(dot11_lengths) >= 200
+
+
+def test_synthetic_capture_repeats_story_for_larger_counts(tmp_path: Path):
+    capture_path = tmp_path / "synthetic-long.pcap"
+
+    write_synthetic_capture(capture_path, packet_count=260)
+    rows = [record.to_dict() for record in iter_packet_records([capture_path])]
+
+    assert len(rows) == 260
+    assert rows[-1]["timestamp"] > rows[0]["timestamp"]
+    assert all(row["parse_ok"] for row in rows)


### PR DESCRIPTION
Closes #32

## Summary

- Replaced the flat modulo-based synthetic packet generator with a deterministic 120-frame fake household traffic story.
- Added richer metadata variation across source/destination MACs, channels, rates, subtypes, RSSI, frame sizes, retries, and timestamps while preserving the existing synthetic demo path and default packet count.
- Updated the generator help text plus README/example docs to describe what the synthetic capture demonstrates.
- Added tests that assert the richer fixture remains parseable, varied, deterministic, and safe for larger packet counts.

## Validation

- `make check PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest tests/test_synthetic_capture.py tests/test_demo_pipeline.py::test_synthetic_capture_cli_pipeline tests/test_demo_pipeline.py::test_synthetic_capture_full_cli_demo_pipeline -q --no-cov`
- `.venv/bin/python -m ruff check src/peekaboo/capture/synthetic.py examples/generate_synthetic_capture.py tests/test_synthetic_capture.py README.md examples/README.md`
- `.venv/bin/python examples/generate_synthetic_capture.py && .venv/bin/peekaboo run --config configs/synthetic-demo.yaml --force --quiet`

## Safety

This remains synthetic-only, passive-only, and metadata-only. It does not decrypt traffic, inspect payloads, capture real network traffic, inject frames, probe networks, configure adapters, or channel hop.