### PR TITLE
[codex] Add coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,11 @@ jobs:
         run: python -m compileall -q src tests
 
       - name: Test with coverage
-        run: python -m pytest -q
+        run: python -m pytest -q --cov-report=xml
+
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .ruff_cache/
 .mypy_cache/
 .coverage
+coverage.xml
 htmlcov/
 
 # Virtual environments

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ check: lint
 	$(PYTHON) -m pytest -q
 
 coverage:
-	$(PYTHON) -m pytest -q --cov-report=term-missing --cov-report=html
+	$(PYTHON) -m pytest -q --cov-report=term-missing --cov-report=html --cov-report=xml
 
 build:
 	$(PYTHON) -m build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # peekaboo
 
 [![CI](https://github.com/keithwegner/peekaboo/actions/workflows/ci.yml/badge.svg)](https://github.com/keithwegner/peekaboo/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/keithwegner/peekaboo/branch/main/graph/badge.svg)](https://codecov.io/gh/keithwegner/peekaboo)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![Ruff](https://img.shields.io/badge/lint-ruff-46a6ff)](https://docs.astral.sh/ruff/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](./pyproject.toml)


### PR DESCRIPTION
## Summary

- Adds a Codecov coverage badge to the README.
- Makes CI generate `coverage.xml` during the pytest coverage run.
- Uploads coverage from the Python 3.12 CI job using `codecov/codecov-action@v5`.
- Updates `make coverage` to emit XML locally and ignores generated `coverage.xml`.

## Validation

- `make check PYTHON=.venv/bin/python`
- `make coverage PYTHON=.venv/bin/python`

## Notes

The Codecov badge may show an initial unknown/no-data state until the first successful upload lands on `main` and Codecov indexes the repository.